### PR TITLE
fix: repair Release source and smoke checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 #   2) 构建源码包 (sdist + wheel)
 #   3) 构建 Payload + 契约验证
 #   4) 构建 Windows Lite EXE (PyInstaller)
-#   5) Lite EXE smoke tests (--version / --diagnose / 空目录安装 / 联网安装 / 二次禁网)
+#   5) Lite EXE smoke tests (--version / --doctor / 空目录安装 / 联网安装 / 二次禁网)
 #   6) Full Bundle 离线安装测试
 #   7) 上传到 GitHub Release
 name: Release
@@ -421,12 +421,12 @@ jobs:
           if ($LASTEXITCODE -ne 0) { Write-Error "Lite EXE --version failed (exit=$LASTEXITCODE)"; exit 1 }
         timeout-minutes: 5
 
-      - name: Lite EXE --diagnose
+      - name: Lite EXE --doctor
         shell: pwsh
         run: |
           $exe = Get-ChildItem smoke/lite/*.exe | Select-Object -First 1
-          & $exe.FullName --diagnose 2>&1 | Out-Host
-          if ($LASTEXITCODE -ne 0) { Write-Warning "--diagnose returned non-zero (expected without models)" }
+          & $exe.FullName --doctor 2>&1 | Out-Host
+          if ($LASTEXITCODE -ne 0) { Write-Error "Lite EXE --doctor failed (exit=$LASTEXITCODE)"; exit 1 }
         timeout-minutes: 5
 
       - name: Lite fresh-install to empty directory

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,7 @@ include packaging/docker/Dockerfile
 recursive-include app *.py *.html *.css *.js *.txt
 recursive-include config *.yaml *.txt
 recursive-include docs *.md
-recursive-include packaging *.py *.json *.yaml *.ini *.lock *.spec *.md *.example
+recursive-include packaging *.py *.json *.yaml *.ini *.lock *.in *.spec *.md *.example
 recursive-include scripts *.py *.json *.sh *.bat
 recursive-include tests *.py *.json
 recursive-include tools *.py *.pyx *.c *.rs *.toml *.lock

--- a/packaging/portable/tests/test_release_fixture.py
+++ b/packaging/portable/tests/test_release_fixture.py
@@ -14,7 +14,8 @@ def test_release_workflow_has_smoke_tests() -> None:
     content = release_yml.read_text(encoding="utf-8")
     assert "smoke-test:" in content, "Release workflow missing smoke-test job"
     assert "--version" in content, "Release workflow missing Lite EXE --version smoke test"
-    assert "--diagnose" in content, "Release workflow missing Lite EXE --diagnose smoke test"
+    assert "--doctor" in content, "Release workflow missing Lite EXE --doctor smoke test"
+    assert "--diagnose" not in content, "Release workflow calls an unsupported launcher argument"
 
 
 def test_release_workflow_has_tag_validation() -> None:

--- a/tests/unit/test_distribution_artifacts.py
+++ b/tests/unit/test_distribution_artifacts.py
@@ -47,7 +47,7 @@ def test_sdist_manifest_contains_runtime_and_audit_inputs() -> None:
     for rule in (
         "recursive-include app *.py *.html *.css *.js *.txt",
         "recursive-include config *.yaml *.txt",
-        "recursive-include packaging",
+        "recursive-include packaging *.py *.json *.yaml *.ini *.lock *.in *.spec *.md *.example",
         "recursive-include scripts",
         "recursive-include tests",
         "recursive-include tools",


### PR DESCRIPTION
## Summary

- include Portable `*.in` lock inputs in the source distribution manifest
- tighten the distribution contract so future runtime lock inputs cannot be omitted silently
- call the supported Lite launcher `--doctor` command in Release smoke tests
- make a failed Lite diagnostic smoke test fail explicitly instead of continuing with a warning

## Root causes

Release run 29800791142 exposed two independent workflow defects:

1. `Build source packages` → `Validate source manifest` failed because `packaging/portable/locks/requirements-runtime.in` was tracked by Git but excluded from the sdist. The manifest included `*.lock` files but not `*.in` files.
2. The downstream `Smoke tests (Lite + Full)` job called the Lite EXE with unsupported argument `--diagnose`; the launcher exposes `--doctor`. The resulting argparse failure left a non-zero process exit code and failed the step.

## Validation

- exact source-manifest validation now passes with `check-manifest`
- built sdist and wheel successfully; `twine check --strict` passed for both
- verified the sdist contains `requirements-runtime.in` and excludes build/workspace contamination
- installed the built wheel with `[web]` into a fresh venv; Web/config assets and `blc version` smoke tests passed
- targeted Release fixture and launcher tests passed (17 tests)
- Release workflow YAML parsed successfully
- complete `scripts/release_gate.py` passed: 39/39 release audit, version consistency, Ruff, payload contract, main tests, and Portable tests with no skips
