### PR TITLE
修复 Full Bundle 离线依赖安装回退镜像的问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,9 +482,11 @@ jobs:
             & "$root\portable-python\python.exe" -m venv $venv
             if ($LASTEXITCODE -ne 0) { throw "Bundled Python cannot create a venv" }
             $venvPython = "$venv\Scripts\python.exe"
-            & $venvPython -m pip install --no-index --find-links "$root\vendor\wheels" --require-hashes `
-              -r packaging/portable/locks/requirements-runtime-py312-win-x64.lock
-            if ($LASTEXITCODE -ne 0) { throw "Full Bundle offline dependency install failed" }
+            $env:PYTHONPATH = (Resolve-Path "packaging/portable/src").Path
+            $env:BLC_SMOKE_VENV_PYTHON = $venvPython
+            $env:BLC_SMOKE_APP_ROOT = $root
+            & $venvPython -c "import os; from pathlib import Path; from blc_portable.launcher.main import install_dependencies; install_dependencies(Path(os.environ['BLC_SMOKE_VENV_PYTHON']), Path(os.environ['BLC_SMOKE_APP_ROOT']))"
+            if ($LASTEXITCODE -ne 0) { throw "Full Bundle launcher dependency install failed" }
             & $venvPython -m pip check
             if ($LASTEXITCODE -ne 0) { throw "Full Bundle pip check failed" }
             & $venvPython -c "import brotli, fastapi, funasr, loguru, modelscope, pydantic_settings, sqlmodel, torch, torchaudio, uvicorn"

--- a/packaging/portable/README.md
+++ b/packaging/portable/README.md
@@ -249,7 +249,7 @@ python -m pip install setuptools==83.0.0 wheel==0.46.3
 python scripts/generate_portable_runtime_locks.py
 ```
 
-Release CI 会对两套锁执行 `pip download --require-hashes`，并分别进行 Python 3.11 和 3.12 的全新虚拟环境 `--no-index` 离线安装、`pip check` 与核心模块导入测试。不要通过删除哈希、添加 `--no-deps` 或跳过离线安装来规避锁文件错误。
+Release CI 会对两套锁执行 `pip download --require-hashes`，并分别进行 Python 3.11 和 3.12 的全新虚拟环境 `--no-index` 离线安装、`pip check` 与核心模块导入测试。Full Launcher 会自动发现安装目录下的 `vendor/wheels` 并强制使用 `--no-index --require-hashes`，无需设置 `PIP_NO_INDEX`；若 Full wheelhouse 缺失或为空则直接失败，不会回退到在线镜像。不要通过删除哈希、添加 `--no-deps` 或跳过离线安装来规避锁文件错误。
 
 ### 方式三：开发者手动打包
 

--- a/packaging/portable/src/blc_portable/launcher/main.py
+++ b/packaging/portable/src/blc_portable/launcher/main.py
@@ -307,6 +307,18 @@ def _find_lock_file(venv_python: Path) -> Path:
     raise RuntimeError(f"Lock file not found: {lock_name}\nOnly Python 3.11 and 3.12 are supported.")
 
 
+def _find_local_wheelhouse(app_root: Path) -> Path | None:
+    """Find a non-empty Full Bundle wheelhouse under the application root.
+
+    :param app_root: Portable application root directory.
+    :returns: The local wheelhouse path, or ``None`` when it is unavailable.
+    """
+    wheelhouse = app_root / WHEELS_DIR
+    if wheelhouse.is_dir() and any(wheelhouse.glob("*.whl")):
+        return wheelhouse
+    return None
+
+
 def install_dependencies(venv_python: Path, app_root: Path, req_file: Path | None = None) -> None:
     """Install Python dependencies from ABI-specific lock file.
 
@@ -355,13 +367,19 @@ def install_dependencies(venv_python: Path, app_root: Path, req_file: Path | Non
 
     # Install from lock file with mandatory hash verification
     print(f"  install deps (lock file: {lock_file.name})...")
-    offline_flag = []
-    if os.environ.get("PIP_NO_INDEX") == "1":
-        wheelhouse = Path(__file__).resolve().parent.parent.parent.parent / "vendor" / "wheels"
-        if wheelhouse.exists() and list(wheelhouse.glob("*.whl")):
-            offline_flag = ["--no-index", "--find-links", str(wheelhouse)]
-        else:
-            offline_flag = ["--no-index"]
+    wheelhouse = _find_local_wheelhouse(app_root)
+    if wheelhouse is not None:
+        print(f"  local wheelhouse detected, enforcing offline install: {wheelhouse}")
+        offline_flag = ["--no-index", "--find-links", str(wheelhouse)]
+    elif (app_root / "portable-python" / "python.exe").is_file():
+        raise RuntimeError(
+            "Full Bundle wheelhouse is missing or empty: "
+            f"{app_root / WHEELS_DIR}\nRefusing to download dependencies from the network."
+        )
+    elif os.environ.get("PIP_NO_INDEX") == "1":
+        offline_flag = ["--no-index"]
+    else:
+        offline_flag = []
     subprocess.run(
         [str(venv_python), "-m", "pip", "install", "-r", str(lock_file), "--require-hashes"] + offline_flag,
         check=True,

--- a/packaging/portable/tests/test_install_deps.py
+++ b/packaging/portable/tests/test_install_deps.py
@@ -108,6 +108,60 @@ def test_install_dependencies_recognizes_strict_hash_lock_versions(
     assert len(calls) == 1
 
 
+def test_install_dependencies_auto_uses_full_bundle_wheelhouse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full Bundle must use app_root/vendor/wheels without an environment flag."""
+    from blc_portable.launcher import main  # noqa: E402
+
+    lock_file = tmp_path / "requirements-runtime-py312-win-x64.lock"
+    lock_file.write_text("demo==1.0 --hash=sha256:" + "0" * 64 + "  # demo-1.0-py3-none-any.whl\n")
+    wheelhouse = tmp_path / "vendor" / "wheels"
+    wheelhouse.mkdir(parents=True)
+    (wheelhouse / "demo-1.0-py3-none-any.whl").write_bytes(b"fixture")
+    calls: list[list[str]] = []
+
+    def _fake_run(args: list[str], **_kwargs: object) -> _sp.CompletedProcess[str]:
+        calls.append(args)
+        if args[-2:] == ["pip", "freeze"]:
+            return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+        return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.delenv("PIP_NO_INDEX", raising=False)
+    monkeypatch.setattr(main, "_find_lock_file", lambda _python: lock_file)
+    monkeypatch.setattr(main.subprocess, "run", _fake_run)
+
+    main.install_dependencies(Path(sys.executable), tmp_path)
+
+    install_call = next(args for args in calls if "install" in args)
+    assert "--require-hashes" in install_call
+    assert "--no-index" in install_call
+    assert install_call[install_call.index("--find-links") + 1] == str(wheelhouse)
+    assert not any("aliyun" in arg or "tsinghua" in arg for arg in install_call)
+
+
+def test_install_dependencies_rejects_full_bundle_without_wheelhouse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An incomplete Full Bundle must fail closed instead of using a package index."""
+    from blc_portable.launcher import main  # noqa: E402
+
+    lock_file = tmp_path / "requirements-runtime-py312-win-x64.lock"
+    lock_file.write_text("demo==1.0 --hash=sha256:" + "0" * 64 + "  # demo-1.0-py3-none-any.whl\n")
+    portable_python = tmp_path / "portable-python" / "python.exe"
+    portable_python.parent.mkdir(parents=True)
+    portable_python.write_bytes(b"fixture")
+
+    def _fake_run(args: list[str], **_kwargs: object) -> _sp.CompletedProcess[str]:
+        assert args[-2:] == ["pip", "freeze"]
+        return _sp.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.delenv("PIP_NO_INDEX", raising=False)
+    monkeypatch.setattr(main, "_find_lock_file", lambda _python: lock_file)
+    monkeypatch.setattr(main.subprocess, "run", _fake_run)
+
+    with pytest.raises(RuntimeError, match="wheelhouse is missing or empty"):
+        main.install_dependencies(Path(sys.executable), tmp_path)
+
+
 def test_lock_files_exist_in_disk() -> None:
     """Both py311 and py312 lock files must exist on disk."""
     assert (_lock_dir / "requirements-runtime-py311-win-x64.lock").exists()

--- a/packaging/portable/tests/test_runtime_locks.py
+++ b/packaging/portable/tests/test_runtime_locks.py
@@ -102,7 +102,9 @@ def test_release_workflow_performs_real_offline_installs() -> None:
     workflow = (_repo_root / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     assert "scripts/build_portable_runtime_wheels.py" in workflow
-    assert workflow.count("--require-hashes") >= 4
-    assert workflow.count("--no-index") >= 2
+    assert workflow.count("--require-hashes") >= 3
+    assert workflow.count("--no-index") >= 1
     assert 'portable-python\\python.exe" -m venv' in workflow
+    assert "from blc_portable.launcher.main import install_dependencies" in workflow
+    assert "Full Bundle launcher dependency install failed" in workflow
     assert "Full bundle offline installation OK" in workflow


### PR DESCRIPTION
## 问题

Full Bundle 首次启动时，Launcher 只有在外部设置 `PIP_NO_INDEX=1` 时才启用离线安装，并从 PyInstaller 临时目录推导 wheelhouse。用户双击启动没有该环境变量，导致 pip 访问阿里云镜像并下载同版本 sdist；锁文件固定的是随包 wheel 哈希，因此 `--require-hashes` 正确拒绝安装。

## 修复

- 从应用根目录自动发现 `vendor/wheels`。
- 发现 wheelhouse 时强制使用 `--no-index --find-links --require-hashes`。
- Full 结构缺少或空 wheelhouse 时失败关闭，禁止回退在线镜像。
- Release CI 从 Full ZIP 解包后调用真实 `install_dependencies()` 验证 Launcher 路径。
- 增加无环境变量自动离线与缺件失败关闭回归测试。
- 未修改运行时锁，也未加入阿里云 sdist 哈希。

## 验证

- 目标回归测试 29/29 通过。
- `scripts/release_gate.py` 全绿：Release Audit 39/39、Ruff、主测试全量、Portable 测试全量及 184 文件 Payload 合约均通过。
- Rust 构建、sdist/wheel 构建、`twine check --strict`、Lite EXE 实际构建与 `--version` 冒烟通过。
- Full 本地构建缺件门禁通过；本机缺少 Portable Python、完整 wheelhouse 与 FFmpeg，真实 Full ZIP 将由 Release CI 构建，并通过修复后的 Launcher 安装函数验证。
- `git diff --check` 与敏感信息扫描通过。
