### PR TITLE
补齐 V0.1.15.1 Engine Pack 合规构建与版本说明

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ recursive-include app *.py *.html *.css *.js *.txt
 recursive-include config *.yaml *.txt
 recursive-include docs *.md
 recursive-include packaging *.py *.json *.yaml *.ini *.lock *.in *.spec *.md *.example
+recursive-include packaging/portable/licenses *.txt
 recursive-include scripts *.py *.json *.sh *.bat
 recursive-include tests *.py *.json
 recursive-include tools *.py *.pyx *.c *.rs *.toml *.lock

--- a/README.md
+++ b/README.md
@@ -17,10 +17,31 @@
 > python build_engine_pack.py --from-cache  # 构建 Engine Pack ZIP
 > ```
 > 生成的 ZIP 放在便携版同目录下，首次启动时自动校验 CRC32/SHA-256 并安装模型。
+> 正式构建会校验每个主模型、子模型和随附组件的固定 revision、目录契约及再分发许可证；包内附带 MIT、Apache-2.0 原文和[第三方模型声明](packaging/portable/licenses/THIRD_PARTY_NOTICES.md)。
 
-## V0.1.14.7 新特性：发行结构重构
+## V0.1.15 新特性：V0.1.14 稳定性收口与 Portable 发布
 
-解决中国大陆 GitHub 不稳定问题，建立从固定 Git Commit 提取源码、嵌入 Portable EXE 的发行链路。彻底摆脱首发时对 GitHub 的依赖。
+**V0.1.15 是对 V0.1.14 架构重构与稳定性治理的发布收口。** V0.1.14 完成了模块拆分、状态恢复、数据一致性和发布安全基础；V0.1.15 将这些能力收敛为可复现、可离线安装、可供普通 Windows 用户直接测试的 Portable 发行链路。当前补丁版本为 `V0.1.15.1 Alpha`。
+
+### Portable 发布闭环
+
+- **固定业务源码**：Payload 从提交 `1b47a09` 通过 `git archive` 提取，不混入构建机工作区内容。
+- **Lite / Full 双发行**：Lite 保持单 EXE；Full 自带 Python 3.12、严格哈希锁定的离线 wheelhouse、FFmpeg 和 FFprobe。
+- **离线依赖可验证**：Full 安装强制使用本地 wheelhouse，安装后执行 `pip check`、核心模块和 `app.cli` 导入冒烟测试。
+- **原子 Runtime 安装**：使用内容寻址 Release ID、staging 原子切换和 `current.json`，升级失败不会破坏已安装版本。
+- **完整性与解压安全**：Payload 和 Engine Pack 使用 SHA-256/CRC32、逐文件 Manifest，并拒绝绝对路径、`..`、盘符路径和符号链接。
+
+### 首次使用与账号登录
+
+- 登录窗口优先调用电脑已安装的 Google Chrome；找不到时复用或按需下载 Playwright Chromium。
+- Playwright 已进入 Portable 运行时锁和安装导入检查，不再要求用户预先手工安装浏览器组件。
+- 新增 [Portable 小白使用说明](packaging/portable/USER_GUIDE_ZH.md)，覆盖下载、校验、解压、启动、配置、首次录制和常见故障排查。
+
+### 发布质量收口
+
+- 版本号、Portable 元数据、Rust SemVer、构建脚本、工作流和说明文档统一由发布检查交叉验证。
+- `main` CI 覆盖 Ubuntu、Windows、macOS、Python 3.11–3.13、Portable、依赖审计、覆盖率和 CodeQL。
+- 完整发布门禁验证可复现 Payload、主项目测试、Portable 测试、Ruff 和版本一致性；原生扩展不可用时保留经过测试的纯 Python 回退。
 
 ```text
 用户取得 Portable EXE → 双击运行 → 读取内置 Payload → 不访问 GitHub → 校验 SHA-256 → 释放源码 → 启动
@@ -32,10 +53,11 @@
 | **零 GitHub 请求** | 首次启动完全从 EXE 内置 Payload 释放源码，不访问 GitHub |
 | **可复现 Payload** | 相同输入构建两次 SHA-256 完全一致，并在发布门禁中自动验证 |
 | **原子 Runtime 安装** | `staging → rename` 原子切换，`current.json` 原子更新 |
-| **Lite / Full 双发行** | Lite: 轻量化单 EXE，安装时联网下载依赖；Full: 预置 Portable Python + Wheels + FFmpeg，安装无需额外下载 |
-| **Zip Slip 防护** | 解压拒绝绝对路径、`..` 和盘符路径 |
+| **Lite / Full 双发行** | Lite：轻量单 EXE，安装时联网下载依赖；Full：预置 Portable Python、离线 Wheels 和 FFmpeg |
+| **Chrome 优先登录** | 优先使用系统 Chrome，不可用时自动安装 Playwright Chromium |
+| **安全解压** | 解压拒绝绝对路径、`..`、盘符路径和符号链接 |
 
-测试: 19 项 Portable 测试 + 308 项主项目测试全部通过，Ruff 零错误。
+> `V0.1.15.1 Alpha` 已通过当前 `main` 全矩阵 CI，适合小规模、受控分发测试；它仍是 Alpha 版本，不等同于面向所有用户的稳定正式版。
 
 详见 [`packaging/portable/README.md`](packaging/portable/README.md)。
 

--- a/packaging/portable/README.md
+++ b/packaging/portable/README.md
@@ -152,8 +152,8 @@ Lite 和 Full 均不携带 ASR 模型。四个引擎模型统一由独立的 **E
 |------|---------|------|------|
 | Whisper (兜底) | faster-whisper-large-v3-turbo | Hugging Face (dropbox-dash/) | 0a363e9161cb |
 | Paraformer-zh (主引擎) | paraformer-zh | ModelScope | v2.0.4 |
-| SenseVoice-Small (辅助特征) | iic/SenseVoiceSmall | ModelScope | v1.0.0 |
-| Fun-ASR-Nano (低置信复核) | FunAudioLLM/Fun-ASR-Nano-2512 | ModelScope | v1.0.0 |
+| SenseVoice-Small (辅助特征) | iic/SenseVoiceSmall | ModelScope | 7bf452403abd |
+| Fun-ASR-Nano (低置信复核) | FunAudioLLM/Fun-ASR-Nano-2512 | ModelScope | 05201c46f1c3 |
 
 > Paraformer 额外需要 `fsmn-vad` / `ct-punc` / `campplus` 三个子模型（自动下载）。
 

--- a/packaging/portable/README.md
+++ b/packaging/portable/README.md
@@ -150,7 +150,7 @@ Lite 和 Full 均不携带 ASR 模型。四个引擎模型统一由独立的 **E
 
 | 引擎 | 模型 ID | 来源 | 版本 |
 |------|---------|------|------|
-| Whisper (兜底) | faster-whisper-large-v3-turbo | Hugging Face (dropbox-dash/) | e4b9645 |
+| Whisper (兜底) | faster-whisper-large-v3-turbo | Hugging Face (dropbox-dash/) | 0a363e9161cb |
 | Paraformer-zh (主引擎) | paraformer-zh | ModelScope | v2.0.4 |
 | SenseVoice-Small (辅助特征) | iic/SenseVoiceSmall | ModelScope | v1.0.0 |
 | Fun-ASR-Nano (低置信复核) | FunAudioLLM/Fun-ASR-Nano-2512 | ModelScope | v1.0.0 |

--- a/packaging/portable/README.md
+++ b/packaging/portable/README.md
@@ -150,12 +150,12 @@ Lite 和 Full 均不携带 ASR 模型。四个引擎模型统一由独立的 **E
 
 | 引擎 | 模型 ID | 来源 | 版本 |
 |------|---------|------|------|
-| Whisper (兜底) | large-v3-turbo | HuggingFace (mobiuslabsgmbh/) | — |
+| Whisper (兜底) | faster-whisper-large-v3-turbo | Hugging Face (dropbox-dash/) | e4b9645 |
 | Paraformer-zh (主引擎) | paraformer-zh | ModelScope | v2.0.4 |
-| SenseVoice-Small (辅助特征) | iic/SenseVoiceSmall | ModelScope | v2.0.4 |
-| Fun-ASR-Nano (低置信复核) | iic/Fun-ASR-Nano | ModelScope | v2.0.4 |
+| SenseVoice-Small (辅助特征) | iic/SenseVoiceSmall | ModelScope | v1.0.0 |
+| Fun-ASR-Nano (低置信复核) | FunAudioLLM/Fun-ASR-Nano-2512 | ModelScope | v1.0.0 |
 
-> Paraformer 额外需要 smn-vad / ct-punc / cam++ 三个子模型 (自动下载)。
+> Paraformer 额外需要 `fsmn-vad` / `ct-punc` / `campplus` 三个子模型（自动下载）。
 
 ### 使用方式
 
@@ -177,7 +177,7 @@ Lite 和 Full 均不携带 ASR 模型。四个引擎模型统一由独立的 **E
 
 ### 模型安装目录
 
-`
+```text
 <程序根目录>/
 ├── BiliLiveCut-Portable.exe
 ├── models/
@@ -186,25 +186,31 @@ Lite 和 Full 均不携带 ASR 模型。四个引擎模型统一由独立的 **E
 │   ├── sensevoice/                 # SenseVoice-Small
 │   ├── funasr_nano/                # Fun-ASR-Nano
 │   └── engine-pack-installed.json  # 安装清单 (自动生成)
-`
+```
 
 模型安装在程序 Portable 根目录的 models/ 下，不写入用户主目录缓存。
 
 ### 构建 Engine Pack
 
-`powershell
+```powershell
 cd packaging\portable
 python build_engine_pack.py           # 真实下载四引擎模型并打包
 python build_engine_pack.py --fixture # 生成测试用小型 Fixture
-`
+python download_engines.py            # 可选：按锁定 revision 建立本地缓存
+python build_engine_pack.py --from-cache  # 从已验证缓存构建
+```
 
 输出:
+
 - dist/engine-pack/BiliLiveCut-EnginePack-0.1.15.1-alpha.zip
 - dist/engine-pack/engine-pack-manifest.json
 - dist/engine-pack/CRC32SUMS.txt
 - dist/engine-pack/SHA256SUMS.txt
+- 包内 licenses/THIRD_PARTY_NOTICES.md、MIT.txt、Apache-2.0.txt
 
 resources/engine_pack_info.json (本地 Engine Pack 构建后可供 Lite/Full EXE 嵌入；GitHub Release 不嵌入 fixture)
+
+正式构建会执行再分发门禁：主模型、Paraformer 子模型及 Fun-ASR-Nano 随附的 Qwen3 组件必须具有固定来源、许可证证据、验证日期和随包许可证文件；任一项缺失都会终止构建。完整归属见 [`licenses/THIRD_PARTY_NOTICES.md`](licenses/THIRD_PARTY_NOTICES.md)。
 
 ### 注意事项
 

--- a/packaging/portable/USER_GUIDE_ZH.md
+++ b/packaging/portable/USER_GUIDE_ZH.md
@@ -41,7 +41,7 @@ Full 版不要求系统安装 Python、FFmpeg、Visual Studio、Git 或其他编
 
 ## 2. 下载正确的文件
 
-打开项目的 [GitHub Releases 页面](https://github.com/StarGazerQQD/BiliLiveCut/releases)，进入 `v0.1.15.1-Alpha`，下载：
+打开项目的 [GitHub Releases 页面](https://github.com/StarGazerQQD/BiliLiveCut/releases)，进入 `v0.1.15.1-alpha`，下载：
 
 1. `BiliLiveCut-Portable-Full-0.1.15.1-alpha-x64.zip`
 2. `SHA256SUMS.txt`

--- a/packaging/portable/config/model_catalog.py
+++ b/packaging/portable/config/model_catalog.py
@@ -21,6 +21,19 @@ _cache: dict | None = None
 
 
 @dataclass
+class LicenseDef:
+    """模型或随附组件的再分发许可证信息。"""
+
+    name: str = ""
+    spdx: str = ""
+    source: str = ""
+    evidence_url: str = ""
+    license_file: str = ""
+    verified_at: str = ""
+    redistribution_verified: bool = False
+
+
+@dataclass
 class SubModelDef:
     """子模型定义（如 Paraformer 的 VAD/标点/声纹）。"""
 
@@ -31,6 +44,19 @@ class SubModelDef:
     requested_revision: str
     resolved_revision: str
     target_subdir: str
+    license: LicenseDef = field(default_factory=LicenseDef)
+
+
+@dataclass
+class ThirdPartyComponentDef:
+    """模型快照内随附、但由另一上游维护的组件。"""
+
+    component_id: str
+    display_name: str
+    repository: str
+    revision: str
+    target_subdir: str
+    license: LicenseDef = field(default_factory=LicenseDef)
 
 
 @dataclass
@@ -46,10 +72,37 @@ class EngineDef:
     target_path: str
     required_files: list[str]
     sub_models: list[SubModelDef] = field(default_factory=list)
+    third_party_components: list[ThirdPartyComponentDef] = field(default_factory=list)
     repo_id: str = ""  # huggingface specific
-    license_name: str = ""
-    license_source: str = ""
-    redistribution_verified: bool = False
+    license: LicenseDef = field(default_factory=LicenseDef)
+
+    @property
+    def license_name(self) -> str:
+        """兼容旧调用方的许可证名称属性。"""
+        return self.license.name
+
+    @property
+    def license_source(self) -> str:
+        """兼容旧调用方的许可证来源属性。"""
+        return self.license.source
+
+    @property
+    def redistribution_verified(self) -> bool:
+        """兼容旧调用方的再分发验证属性。"""
+        return self.license.redistribution_verified
+
+
+def _parse_license(raw: dict) -> LicenseDef:
+    """解析许可证元数据。"""
+    return LicenseDef(
+        name=raw.get("name", ""),
+        spdx=raw.get("spdx", raw.get("name", "")),
+        source=raw.get("source", ""),
+        evidence_url=raw.get("evidence_url", raw.get("source", "")),
+        license_file=raw.get("license_file", ""),
+        verified_at=raw.get("verified_at", ""),
+        redistribution_verified=raw.get("redistribution_verified", False),
+    )
 
 
 def _load_raw_catalog() -> dict:
@@ -85,10 +138,23 @@ def _parse_engine(raw: dict) -> EngineDef:
                 requested_revision=sub.get("requested_revision", ""),
                 resolved_revision=sub.get("resolved_revision", ""),
                 target_subdir=sub["target_subdir"],
+                license=_parse_license(sub.get("license", {})),
             )
         )
 
-    license_info = raw.get("license", {})
+    third_party_components = []
+    for component in raw.get("third_party_components", []):
+        third_party_components.append(
+            ThirdPartyComponentDef(
+                component_id=component["component_id"],
+                display_name=component["display_name"],
+                repository=component["repository"],
+                revision=component.get("revision", ""),
+                target_subdir=component["target_subdir"],
+                license=_parse_license(component.get("license", {})),
+            )
+        )
+
     return EngineDef(
         engine_id=raw["engine_id"],
         display_name=raw["display_name"],
@@ -99,10 +165,9 @@ def _parse_engine(raw: dict) -> EngineDef:
         target_path=raw["target_path"],
         required_files=raw.get("required_files", []),
         sub_models=sub_models,
+        third_party_components=third_party_components,
         repo_id=raw.get("repository", "") if raw["hub"] == "huggingface" else "",
-        license_name=license_info.get("name", ""),
-        license_source=license_info.get("source", ""),
-        redistribution_verified=license_info.get("redistribution_verified", False),
+        license=_parse_license(raw.get("license", {})),
     )
 
 
@@ -166,6 +231,20 @@ def validate_catalog() -> list[str]:
     errors: list[str] = []
     catalog = _load_raw_catalog()
 
+    def validate_license(owner: str, license_info: dict) -> None:
+        required = ("name", "spdx", "source", "evidence_url", "license_file", "verified_at")
+        for key in required:
+            if not license_info.get(key):
+                errors.append(f"{owner}: license.{key} 为空")
+        if license_info.get("redistribution_verified") is not True:
+            errors.append(f"{owner}: redistribution_verified 未通过")
+
+        relative_file = Path(str(license_info.get("license_file", "")))
+        if relative_file.is_absolute() or ".." in relative_file.parts:
+            errors.append(f"{owner}: license_file 路径无效")
+        elif relative_file.parts and not (_CATALOG_PATH.parent.parent / relative_file).is_file():
+            errors.append(f"{owner}: license_file 不存在 '{relative_file.as_posix()}'")
+
     seen_ids: set[str] = set()
     seen_paths: set[str] = set()
     for engine in catalog["engines"]:
@@ -185,6 +264,8 @@ def validate_catalog() -> list[str]:
         if not engine.get("required_files"):
             errors.append(f"引擎 {eid}: required_files 为空")
 
+        validate_license(f"引擎 {eid}", engine.get("license", {}))
+
         repo = engine.get("repository", "")
         if not repo or "/" not in repo:
             errors.append(f"引擎 {eid}: repository 格式无效 '{repo}'")
@@ -197,5 +278,23 @@ def validate_catalog() -> list[str]:
             sub_repo = sub.get("repository", "")
             if not sub_repo or "/" not in sub_repo:
                 errors.append(f"引擎 {eid} 子模型 {sub.get('engine_id')}: repository 格式无效")
+            if not sub.get("resolved_revision"):
+                errors.append(f"引擎 {eid} 子模型 {sub.get('engine_id')}: resolved_revision 为空")
+            validate_license(
+                f"引擎 {eid} 子模型 {sub.get('engine_id')}",
+                sub.get("license", {}),
+            )
+
+        for component in engine.get("third_party_components", []):
+            component_id = component.get("component_id")
+            component_repo = component.get("repository", "")
+            if not component_repo or "/" not in component_repo:
+                errors.append(f"引擎 {eid} 随附组件 {component_id}: repository 格式无效")
+            if not component.get("revision"):
+                errors.append(f"引擎 {eid} 随附组件 {component_id}: revision 为空")
+            validate_license(
+                f"引擎 {eid} 随附组件 {component_id}",
+                component.get("license", {}),
+            )
 
     return errors

--- a/packaging/portable/config/model_sources.lock.json
+++ b/packaging/portable/config/model_sources.lock.json
@@ -12,9 +12,9 @@
       "engine_id": "whisper",
       "display_name": "Whisper (faster-whisper large-v3-turbo)",
       "hub": "huggingface",
-      "repository": "mobiuslabsgmbh/faster-whisper-large-v3-turbo",
+      "repository": "dropbox-dash/faster-whisper-large-v3-turbo",
       "requested_revision": "",
-      "resolved_revision": "e4b9645",
+      "resolved_revision": "0a363e9161cbc7ed1431c9597a8ceaf0c4f78fcf",
       "target_path": "models/whisper",
       "required_files": [
         "model.bin",
@@ -27,7 +27,7 @@
       "license": {
         "name": "MIT",
         "spdx": "MIT",
-        "source": "https://huggingface.co/mobiuslabsgmbh/faster-whisper-large-v3-turbo",
+        "source": "https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo",
         "evidence_url": "https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo",
         "license_file": "licenses/MIT.txt",
         "verified_at": "2026-07-22",

--- a/packaging/portable/config/model_sources.lock.json
+++ b/packaging/portable/config/model_sources.lock.json
@@ -26,8 +26,12 @@
       "files": {},
       "license": {
         "name": "MIT",
+        "spdx": "MIT",
         "source": "https://huggingface.co/mobiuslabsgmbh/faster-whisper-large-v3-turbo",
-        "redistribution_verified": false
+        "evidence_url": "https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo",
+        "license_file": "licenses/MIT.txt",
+        "verified_at": "2026-07-22",
+        "redistribution_verified": true
       }
     },
     {
@@ -54,7 +58,16 @@
           "repository": "iic/speech_fsmn_vad_zh-cn-16k-common-pytorch",
           "requested_revision": "v2.0.4",
           "resolved_revision": "v2.0.4",
-          "target_subdir": "fsmn-vad"
+          "target_subdir": "fsmn-vad",
+          "license": {
+            "name": "Apache-2.0",
+            "spdx": "Apache-2.0",
+            "source": "https://modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-pytorch",
+            "evidence_url": "https://modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-pytorch/summary",
+            "license_file": "licenses/Apache-2.0.txt",
+            "verified_at": "2026-07-22",
+            "redistribution_verified": true
+          }
         },
         {
           "engine_id": "paraformer_punc",
@@ -63,7 +76,16 @@
           "repository": "iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
           "requested_revision": "v2.0.4",
           "resolved_revision": "v2.0.4",
-          "target_subdir": "ct-punc"
+          "target_subdir": "ct-punc",
+          "license": {
+            "name": "Apache-2.0",
+            "spdx": "Apache-2.0",
+            "source": "https://modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
+            "evidence_url": "https://modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch",
+            "license_file": "licenses/Apache-2.0.txt",
+            "verified_at": "2026-07-22",
+            "redistribution_verified": true
+          }
         },
         {
           "engine_id": "paraformer_campplus",
@@ -72,14 +94,27 @@
           "repository": "iic/speech_campplus_sv_zh-cn_16k-common",
           "requested_revision": "v1.0.0",
           "resolved_revision": "v1.0.0",
-          "target_subdir": "campplus"
+          "target_subdir": "campplus",
+          "license": {
+            "name": "Apache-2.0",
+            "spdx": "Apache-2.0",
+            "source": "https://modelscope.cn/models/iic/speech_campplus_sv_zh-cn_16k-common",
+            "evidence_url": "https://modelscope.cn/models/iic/speech_campplus_sv_zh-cn_16k-common",
+            "license_file": "licenses/Apache-2.0.txt",
+            "verified_at": "2026-07-22",
+            "redistribution_verified": true
+          }
         }
       ],
       "files": {},
       "license": {
         "name": "Apache-2.0",
+        "spdx": "Apache-2.0",
         "source": "https://modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
-        "redistribution_verified": false
+        "evidence_url": "https://modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+        "license_file": "licenses/Apache-2.0.txt",
+        "verified_at": "2026-07-22",
+        "redistribution_verified": true
       }
     },
     {
@@ -101,8 +136,12 @@
       "files": {},
       "license": {
         "name": "Apache-2.0",
+        "spdx": "Apache-2.0",
         "source": "https://modelscope.cn/models/iic/SenseVoiceSmall",
-        "redistribution_verified": false
+        "evidence_url": "https://modelscope.cn/models/iic/SenseVoiceSmall",
+        "license_file": "licenses/Apache-2.0.txt",
+        "verified_at": "2026-07-22",
+        "redistribution_verified": true
       }
     },
     {
@@ -120,10 +159,32 @@
         "multilingual.tiktoken"
       ],
       "files": {},
+      "third_party_components": [
+        {
+          "component_id": "qwen3_0_6b",
+          "display_name": "Qwen3-0.6B 随附组件",
+          "repository": "Qwen/Qwen3-0.6B",
+          "revision": "included-in-funasr-nano-v1.0.0",
+          "target_subdir": "Qwen3-0.6B",
+          "license": {
+            "name": "Apache-2.0",
+            "spdx": "Apache-2.0",
+            "source": "https://huggingface.co/Qwen/Qwen3-0.6B",
+            "evidence_url": "https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/LICENSE",
+            "license_file": "licenses/Apache-2.0.txt",
+            "verified_at": "2026-07-22",
+            "redistribution_verified": true
+          }
+        }
+      ],
       "license": {
         "name": "Apache-2.0",
+        "spdx": "Apache-2.0",
         "source": "https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512",
-        "redistribution_verified": false
+        "evidence_url": "https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512",
+        "license_file": "licenses/Apache-2.0.txt",
+        "verified_at": "2026-07-22",
+        "redistribution_verified": true
       }
     }
   ]

--- a/packaging/portable/config/model_sources.lock.json
+++ b/packaging/portable/config/model_sources.lock.json
@@ -122,8 +122,8 @@
       "display_name": "SenseVoice-Small (辅助特征引擎)",
       "hub": "modelscope",
       "repository": "iic/SenseVoiceSmall",
-      "requested_revision": "",
-      "resolved_revision": "v1.0.0",
+      "requested_revision": "master",
+      "resolved_revision": "7bf452403abd7353a300cd760f7adae7701c92c1",
       "target_path": "models/sensevoice",
       "required_files": [
         "model.pt",
@@ -149,8 +149,8 @@
       "display_name": "Fun-ASR-Nano (低置信度复核引擎)",
       "hub": "modelscope",
       "repository": "FunAudioLLM/Fun-ASR-Nano-2512",
-      "requested_revision": "",
-      "resolved_revision": "v1.0.0",
+      "requested_revision": "master",
+      "resolved_revision": "05201c46f1c38592b1567f857c0d56eab3d0d8ef",
       "target_path": "models/funasr_nano",
       "required_files": [
         "model.pt",
@@ -164,7 +164,7 @@
           "component_id": "qwen3_0_6b",
           "display_name": "Qwen3-0.6B 随附组件",
           "repository": "Qwen/Qwen3-0.6B",
-          "revision": "included-in-funasr-nano-v1.0.0",
+          "revision": "included-in-funasr-nano-05201c46f1c38592b1567f857c0d56eab3d0d8ef",
           "target_subdir": "Qwen3-0.6B",
           "license": {
             "name": "Apache-2.0",

--- a/packaging/portable/licenses/Apache-2.0.txt
+++ b/packaging/portable/licenses/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packaging/portable/licenses/MIT.txt
+++ b/packaging/portable/licenses/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 OpenAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packaging/portable/licenses/THIRD_PARTY_NOTICES.md
+++ b/packaging/portable/licenses/THIRD_PARTY_NOTICES.md
@@ -6,7 +6,7 @@
 
 | 组件 | 上游来源 | 固定 revision | 许可证 |
 | --- | --- | --- | --- |
-| Whisper large-v3-turbo（CTranslate2 转换） | https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo | `e4b9645` | MIT |
+| Whisper large-v3-turbo（CTranslate2 转换） | https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo | `0a363e9161cbc7ed1431c9597a8ceaf0c4f78fcf` | MIT |
 | OpenAI Whisper 原始权重 | https://github.com/openai/whisper | `large-v3-turbo` 上游模型 | MIT |
 | Paraformer-zh | https://modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch | `v2.0.4` | Apache-2.0 |
 | FSMN-VAD | https://modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-pytorch | `v2.0.4` | Apache-2.0 |

--- a/packaging/portable/licenses/THIRD_PARTY_NOTICES.md
+++ b/packaging/portable/licenses/THIRD_PARTY_NOTICES.md
@@ -12,9 +12,9 @@
 | FSMN-VAD | https://modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-pytorch | `v2.0.4` | Apache-2.0 |
 | CT-Transformer 标点模型 | https://modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch | `v2.0.4` | Apache-2.0 |
 | CAM++ 说话人模型 | https://modelscope.cn/models/iic/speech_campplus_sv_zh-cn_16k-common | `v1.0.0` | Apache-2.0 |
-| SenseVoiceSmall | https://modelscope.cn/models/iic/SenseVoiceSmall | `v1.0.0` | Apache-2.0 |
-| Fun-ASR-Nano-2512 | https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512 | `v1.0.0` | Apache-2.0 |
-| Qwen3-0.6B 随附组件 | https://huggingface.co/Qwen/Qwen3-0.6B | 随 Fun-ASR-Nano `v1.0.0` 固定 | Apache-2.0 |
+| SenseVoiceSmall | https://modelscope.cn/models/iic/SenseVoiceSmall | `7bf452403abd7353a300cd760f7adae7701c92c1` | Apache-2.0 |
+| Fun-ASR-Nano-2512 | https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512 | `05201c46f1c38592b1567f857c0d56eab3d0d8ef` | Apache-2.0 |
+| Qwen3-0.6B 随附组件 | https://huggingface.co/Qwen/Qwen3-0.6B | 随 Fun-ASR-Nano `05201c46f1c38592b1567f857c0d56eab3d0d8ef` 固定 | Apache-2.0 |
 
 ## 许可证文件
 

--- a/packaging/portable/licenses/THIRD_PARTY_NOTICES.md
+++ b/packaging/portable/licenses/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,26 @@
+# BiliLiveCut Engine Pack 第三方模型声明
+
+适用产物：`BiliLiveCut-EnginePack-0.1.15.1-alpha.zip`
+
+本 Engine Pack 包含来自下列上游项目的模型权重、配置、词表和示例文件。模型来源、固定 revision、许可证证据和验证日期同时记录在 `model_sources.lock.json` 与包内 `engine-pack-manifest.json` 中。构建器保留固定模型快照中已有的 README、NOTICE、LICENSE 和归属信息，并额外随包提供本声明及完整许可证文本。
+
+| 组件 | 上游来源 | 固定 revision | 许可证 |
+| --- | --- | --- | --- |
+| Whisper large-v3-turbo（CTranslate2 转换） | https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo | `e4b9645` | MIT |
+| OpenAI Whisper 原始权重 | https://github.com/openai/whisper | `large-v3-turbo` 上游模型 | MIT |
+| Paraformer-zh | https://modelscope.cn/models/iic/speech_paraformer-large-vad-punc_asr_nat-zh-cn-16k-common-vocab8404-pytorch | `v2.0.4` | Apache-2.0 |
+| FSMN-VAD | https://modelscope.cn/models/iic/speech_fsmn_vad_zh-cn-16k-common-pytorch | `v2.0.4` | Apache-2.0 |
+| CT-Transformer 标点模型 | https://modelscope.cn/models/iic/punc_ct-transformer_zh-cn-common-vocab272727-pytorch | `v2.0.4` | Apache-2.0 |
+| CAM++ 说话人模型 | https://modelscope.cn/models/iic/speech_campplus_sv_zh-cn_16k-common | `v1.0.0` | Apache-2.0 |
+| SenseVoiceSmall | https://modelscope.cn/models/iic/SenseVoiceSmall | `v1.0.0` | Apache-2.0 |
+| Fun-ASR-Nano-2512 | https://modelscope.cn/models/FunAudioLLM/Fun-ASR-Nano-2512 | `v1.0.0` | Apache-2.0 |
+| Qwen3-0.6B 随附组件 | https://huggingface.co/Qwen/Qwen3-0.6B | 随 Fun-ASR-Nano `v1.0.0` 固定 | Apache-2.0 |
+
+## 许可证文件
+
+- MIT：`licenses/MIT.txt`
+- Apache License 2.0：`licenses/Apache-2.0.txt`
+
+许可证核验日期：2026-07-22。
+
+本声明用于保留上游归属与许可证信息，不替代许可证原文，也不构成额外授权或法律建议。分发者和使用者仍须遵守各上游许可证及适用法律。

--- a/packaging/portable/src/blc_portable/engine_pack/builder.py
+++ b/packaging/portable/src/blc_portable/engine_pack/builder.py
@@ -4,10 +4,10 @@
     python build_engine_pack.py              # 真实下载四引擎模型
     python build_engine_pack.py --fixture    # 生成测试用 Fixture (小体积)
 
-两阶段构建流程:
-    1. 下载模型 → staging → 第一次打包 (无 Manifest) → 计算 CRC32/SHA256
-    2. 写入完整 Manifest 到 staging → 第二次打包 (含 Manifest)
-    3. 生成 dist/ 输出文件 → 自校验
+构建流程:
+    1. 下载模型并准备 staging
+    2. 生成不自引用、且不包含归档哈希的内容 Manifest
+    3. 一次性打包，计算外部 CRC32/SHA256，生成输出并自校验
 
 输出:
     dist/engine-pack/
@@ -497,7 +497,7 @@ def write_output_files(
     sha256_val: str,
     archive_path: Path,
     source_commit: str,
-    file_list: dict[str, dict[str, object]],
+    content_manifest_path: Path,
     is_fixture: bool,
 ) -> dict[str, Any]:
     """写入 dist/ 下的所有输出文件。
@@ -506,43 +506,21 @@ def write_output_files(
     :param sha256_val: SHA-256 值。
     :param archive_path: ZIP 文件路径。
     :param source_commit: 当前发布基线的完整 Hash。
-    :param file_list: 逐文件清单。
+    :param content_manifest_path: 已写入 ZIP 的内容 Manifest 路径。
     :param is_fixture: 是否为 Fixture。
     :returns: build_manifest 字典。
     """
     DIST_DIR.mkdir(parents=True, exist_ok=True)
 
-    manifest: dict[str, Any] = {
-        "schema_version": 4,
-        "engine_pack_version": ENGINE_PACK_VERSION,
-        "portable_release_version": ENGINE_PACK_VERSION,
-        "source_commit": source_commit,
-        "source_commit_short": SOURCE_COMMIT_SHORT,
-        "archive_filename": archive_path.name,
-        "archive_crc32": crc32_val,
-        "archive_sha256": sha256_val,
-        "total_files": len(file_list),
-        "fixture": is_fixture,
-        "engines": [
-            {
-                "engine_id": e["engine_id"],
-                "engine_name": e["engine_name"],
-                "model_id": e["model_id"],
-                "hub": e["hub"],
-                "revision": e.get("revision"),
-                "target_path": e["target_path"],
-                "license": e["license"],
-                "model_repo": e.get("repo_id"),
-                "sub_models": e.get("sub_models", []),
-                "third_party_components": e.get("third_party_components", []),
-            }
-            for e in _get_engines_for_build()
-        ],
-        "files": file_list,
-    }
-
     manifest_path = DIST_DIR / "engine-pack-manifest.json"
-    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    manifest_bytes = content_manifest_path.read_bytes()
+    manifest = json.loads(manifest_bytes)
+    file_count = int(manifest.get("total_files", 0))
+    if file_count != len(manifest.get("files", {})):
+        raise RuntimeError(
+            f"Content Manifest file count mismatch: declared={file_count} actual={len(manifest.get('files', {}))}"
+        )
+    manifest_path.write_bytes(manifest_bytes)
 
     (DIST_DIR / "CRC32SUMS.txt").write_text(f"{crc32_val}  {archive_path.name}\n", encoding="utf-8")
     (DIST_DIR / "SHA256SUMS.txt").write_text(f"{sha256_val}  {archive_path.name}\n", encoding="utf-8")
@@ -556,7 +534,7 @@ def write_output_files(
         "fixture": is_fixture,
         "archive_crc32": crc32_val,
         "archive_sha256": sha256_val,
-        "file_count": len(file_list),
+        "file_count": file_count,
         "built_at": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
     }
     (DIST_DIR / "build-manifest.json").write_text(
@@ -634,7 +612,7 @@ def write_output_files(
     print(f"\n  Manifest:     {manifest_path}")
     print(f"  CRC32:        {crc32_val}")
     print(f"  SHA-256:      {sha256_val[:32]}...")
-    print(f"  Total files:  {len(file_list)}")
+    print(f"  Total files:  {file_count}")
     print(f"  Size:         {total_size / (1024**3):.2f} GB")
 
     if total_size > 4 * 1024**3:
@@ -696,9 +674,9 @@ def build_engine_pack(fixture: bool = False, from_cache: bool = False) -> dict[s
     - 默认: 直接下载模型到 staging
     - --fixture: 生成测试用 Fixture
     - --from-cache: 从 .model_cache/ 复制已下载的模型 (需先运行 download_engines.py)
-    1. 下载模型 → staging → 第一次打包 → 计算 CRC32/SHA256
-    2. 写入完整 Manifest 到 staging → 第二次打包 (含 Manifest)
-    3. 生成 dist/ 输出 → 自校验
+    1. 下载模型并准备 staging
+    2. 写入不自引用的内容 Manifest
+    3. 一次性打包并生成外部哈希 → 自校验
 
     :param fixture: True 生成测试 Fixture，False 真实下载。
     :param from_cache: 从缓存复制。
@@ -810,24 +788,12 @@ def build_engine_pack(fixture: bool = False, from_cache: bool = False) -> dict[s
     # ── 生成输出文件 ──
     print("\n  生成输出文件 ...")
 
-    manifest_data["archive_crc32"] = final_crc32
-    manifest_data["archive_sha256"] = final_sha256
-
-    (DIST_DIR / "engine-pack-manifest.json").write_text(
-        json.dumps(manifest_data, ensure_ascii=False, indent=2), encoding="utf-8"
-    )
-
-    file_list["engine-pack-manifest.json"] = {
-        "size": (staging / "engine-pack-manifest.json").stat().st_size,
-        "sha256": compute_sha256(staging / "engine-pack-manifest.json"),
-    }
-
     build_result = write_output_files(
         crc32_val=final_crc32,
         sha256_val=final_sha256,
         archive_path=archive_path,
         source_commit=source_commit,
-        file_list=file_list,
+        content_manifest_path=staging / "engine-pack-manifest.json",
         is_fixture=fixture,
     )
 

--- a/packaging/portable/src/blc_portable/engine_pack/builder.py
+++ b/packaging/portable/src/blc_portable/engine_pack/builder.py
@@ -43,12 +43,14 @@ PROJECT_ROOT = PORTABLE_DIR.parent.parent
 BUILD_DIR = PORTABLE_DIR / "build" / "engine-pack"
 DIST_DIR = PORTABLE_DIR / "dist" / "engine-pack"
 RESOURCES_DIR = PORTABLE_DIR / "resources"
+LICENSES_DIR = PORTABLE_DIR / "licenses"
 
 ENGINE_PACK_VERSION = "0.1.15.1-alpha"
 SOURCE_COMMIT_SHORT = "1b47a09"
 ARCHIVE_NAME = f"BiliLiveCut-EnginePack-{ENGINE_PACK_VERSION}"
 
 CHUNK_SIZE = 8 * 1024 * 1024
+MIN_PRODUCTION_ARCHIVE_BYTES = 500 * 1024 * 1024
 
 HF_MIRROR = "https://hf-mirror.com"
 
@@ -65,6 +67,19 @@ if _CONFIG_DIR not in _sys.path:
     _sys.path.insert(0, _CONFIG_DIR)
 
 from model_catalog import load_engines
+
+
+def _license_to_dict(license_def: Any) -> dict[str, object]:
+    """将许可证定义转换为可写入 Manifest 的字典。"""
+    return {
+        "name": license_def.name,
+        "spdx": license_def.spdx,
+        "source": license_def.source,
+        "evidence_url": license_def.evidence_url,
+        "license_file": license_def.license_file,
+        "verified_at": license_def.verified_at,
+        "redistribution_verified": license_def.redistribution_verified,
+    }
 
 
 def _get_engines_for_build() -> list[dict[str, Any]]:
@@ -84,6 +99,8 @@ def _get_engines_for_build() -> list[dict[str, Any]]:
             "hub": e.hub,
             "revision": e.resolved_revision if e.resolved_revision else None,
             "target_path": e.target_path,
+            "required_files": e.required_files,
+            "license": _license_to_dict(e.license),
         }
         if e.hub == "huggingface":
             d["repo_id"] = e.repository
@@ -93,8 +110,21 @@ def _get_engines_for_build() -> list[dict[str, Any]]:
                     "model_id": s.repository,
                     "revision": s.resolved_revision if s.resolved_revision else None,
                     "target_subdir": s.target_subdir if s.target_subdir else s.repository.rsplit("/", 1)[-1],
+                    "license": _license_to_dict(s.license),
                 }
                 for s in e.sub_models
+            ]
+        if e.third_party_components:
+            d["third_party_components"] = [
+                {
+                    "component_id": component.component_id,
+                    "display_name": component.display_name,
+                    "repository": component.repository,
+                    "revision": component.revision,
+                    "target_subdir": component.target_subdir,
+                    "license": _license_to_dict(component.license),
+                }
+                for component in e.third_party_components
             ]
         raw.append(d)
     return raw
@@ -165,6 +195,81 @@ def build_file_list(staging: Path) -> dict[str, dict[str, object]]:
                 "sha256": compute_sha256(p),
             }
     return file_list
+
+
+def validate_redistribution_readiness() -> list[str]:
+    """校验所有主模型、子模型和随附组件的再分发证据。"""
+    errors: list[str] = []
+
+    def validate_license(owner: str, license_data: dict[str, object]) -> None:
+        required = ("name", "spdx", "source", "evidence_url", "license_file", "verified_at")
+        for key in required:
+            if not license_data.get(key):
+                errors.append(f"{owner}: license.{key} missing")
+        if license_data.get("redistribution_verified") is not True:
+            errors.append(f"{owner}: redistribution_verified=false")
+
+        relative_path = Path(str(license_data.get("license_file", "")))
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            errors.append(f"{owner}: invalid license_file path")
+        elif relative_path.parts and not (PORTABLE_DIR / relative_path).is_file():
+            errors.append(f"{owner}: license_file not found: {relative_path.as_posix()}")
+
+    for engine in _get_engines_for_build():
+        engine_id = str(engine["engine_id"])
+        validate_license(f"engine {engine_id}", dict(engine.get("license", {})))
+        for sub_model in engine.get("sub_models", []):
+            validate_license(
+                f"engine {engine_id} sub-model {sub_model.get('model_id', '?')}",
+                dict(sub_model.get("license", {})),
+            )
+        for component in engine.get("third_party_components", []):
+            validate_license(
+                f"engine {engine_id} component {component.get('component_id', '?')}",
+                dict(component.get("license", {})),
+            )
+
+    notice_path = LICENSES_DIR / "THIRD_PARTY_NOTICES.md"
+    if not notice_path.is_file():
+        errors.append(f"third-party notice not found: {notice_path}")
+    return errors
+
+
+def copy_license_materials(staging: Path) -> None:
+    """将第三方许可证与归属声明复制到 Engine Pack。"""
+    if not LICENSES_DIR.is_dir():
+        raise FileNotFoundError(f"许可证目录不存在: {LICENSES_DIR}")
+    shutil.copytree(LICENSES_DIR, staging / "licenses", dirs_exist_ok=True)
+
+
+def validate_prepared_models(staging: Path) -> list[str]:
+    """校验已下载模型是否符合当前锁文件的文件和目录契约。"""
+    errors: list[str] = []
+    for engine in _get_engines_for_build():
+        engine_id = str(engine["engine_id"])
+        target = staging / str(engine["target_path"])
+        if not target.is_dir():
+            errors.append(f"engine {engine_id}: target directory missing: {target}")
+            continue
+
+        for required_file in engine.get("required_files", []):
+            required_path = target / str(required_file)
+            if not required_path.is_file() or required_path.stat().st_size == 0:
+                errors.append(f"engine {engine_id}: required file missing or empty: {required_file}")
+
+        for sub_model in engine.get("sub_models", []):
+            target_subdir = str(sub_model.get("target_subdir", ""))
+            subdir = target / target_subdir
+            if not subdir.is_dir() or not any(path.is_file() for path in subdir.rglob("*")):
+                errors.append(f"engine {engine_id}: sub-model directory missing or empty: {target_subdir}")
+
+        for component in engine.get("third_party_components", []):
+            target_subdir = str(component.get("target_subdir", ""))
+            component_dir = target / target_subdir
+            if not component_dir.is_dir() or not any(path.is_file() for path in component_dir.rglob("*")):
+                errors.append(f"engine {engine_id}: component directory missing or empty: {target_subdir}")
+
+    return errors
 
 
 # ── 真实下载 ──────────────────────────────────────────────
@@ -269,11 +374,27 @@ def build_fixture(staging: Path) -> None:
         # Paraformer 子模型占位
         for sub in engine.get("sub_models", []):
             sub_id = str(sub["model_id"])
-            sub_name = sub_id.rsplit("/", 1)[-1]
+            sub_name = str(sub.get("target_subdir") or sub_id.rsplit("/", 1)[-1])
             sub_dir = target / sub_name
             sub_dir.mkdir(parents=True, exist_ok=True)
             (sub_dir / "model_metadata.json").write_text(
                 json.dumps({"model_id": sub_id, "_fixture": True}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        for component in engine.get("third_party_components", []):
+            component_dir = target / str(component["target_subdir"])
+            component_dir.mkdir(parents=True, exist_ok=True)
+            (component_dir / "component_metadata.json").write_text(
+                json.dumps(
+                    {
+                        "component_id": component["component_id"],
+                        "repository": component["repository"],
+                        "revision": component["revision"],
+                        "_fixture": True,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
                 encoding="utf-8",
             )
 
@@ -343,6 +464,31 @@ def self_verify(archive_path: Path, manifest: dict[str, Any]) -> bool:
         shutil.rmtree(str(verify_dir), ignore_errors=True)
 
 
+def validate_production_metadata(
+    crc32_val: str,
+    sha256_val: str,
+    manifest_sha: str,
+    model_lock_sha: str,
+    builder_head: str,
+    total_size: int,
+) -> list[str]:
+    """校验正式 Engine Pack 外部元数据和最小体积。"""
+    errors: list[str] = []
+    if not crc32_val or len(crc32_val) != 8:
+        errors.append(f"CRC32 invalid: {crc32_val}")
+    if not sha256_val or len(sha256_val) != 64:
+        errors.append(f"SHA-256 invalid: {sha256_val}")
+    if not manifest_sha or len(manifest_sha) != 64:
+        errors.append(f"content_manifest_sha256 invalid: {manifest_sha}")
+    if not model_lock_sha or len(model_lock_sha) != 64:
+        errors.append(f"model_lock_sha256 invalid: {model_lock_sha}")
+    if not builder_head or len(builder_head) != 40:
+        errors.append(f"builder_commit invalid: {builder_head}")
+    if total_size < MIN_PRODUCTION_ARCHIVE_BYTES:
+        errors.append(f"production archive too small: {total_size} bytes (minimum {MIN_PRODUCTION_ARCHIVE_BYTES})")
+    return errors
+
+
 # ── 输出文件 ──────────────────────────────────────────────
 
 
@@ -385,8 +531,10 @@ def write_output_files(
                 "hub": e["hub"],
                 "revision": e.get("revision"),
                 "target_path": e["target_path"],
+                "license": e["license"],
                 "model_repo": e.get("repo_id"),
                 "sub_models": e.get("sub_models", []),
+                "third_party_components": e.get("third_party_components", []),
             }
             for e in _get_engines_for_build()
         ],
@@ -469,17 +617,14 @@ def write_output_files(
 
     # Production validation: reject empty hash fields
     if not is_fixture:
-        errors = []
-        if not crc32_val or len(crc32_val) != 8:
-            errors.append(f"CRC32 invalid: {crc32_val}")
-        if not sha256_val or len(sha256_val) != 64:
-            errors.append(f"SHA-256 invalid: {sha256_val}")
-        if not manifest_sha or len(manifest_sha) != 64:
-            errors.append(f"content_manifest_sha256 invalid: {manifest_sha}")
-        if not model_lock_sha or len(model_lock_sha) != 64:
-            errors.append(f"model_lock_sha256 invalid: {model_lock_sha}")
-        if not builder_head or len(builder_head) != 40:
-            errors.append(f"builder_commit invalid: {builder_head}")
+        errors = validate_production_metadata(
+            crc32_val,
+            sha256_val,
+            manifest_sha,
+            model_lock_sha,
+            builder_head,
+            total_size,
+        )
         if errors:
             raise RuntimeError("Engine Pack production metadata validation FAILED:\n  " + "\n  ".join(errors))
     (RESOURCES_DIR / "engine_pack_info.json").write_text(
@@ -499,7 +644,7 @@ def write_output_files(
 
 
 def copy_from_cache(staging: Path) -> None:
-    """从持久模型缓存 (build/model_cache/) 复制引擎到 staging 目录。
+    """从持久模型缓存 (.model_cache/) 复制引擎到 staging 目录。
 
     :param staging: staging 根目录。
     :raises FileNotFoundError: 缓存目录缺失时。
@@ -550,7 +695,7 @@ def build_engine_pack(fixture: bool = False, from_cache: bool = False) -> dict[s
     支持三种模式:
     - 默认: 直接下载模型到 staging
     - --fixture: 生成测试用 Fixture
-    - --from-cache: 从 build/model_cache/ 复制已下载的模型 (需先运行 download_engines.py)
+    - --from-cache: 从 .model_cache/ 复制已下载的模型 (需先运行 download_engines.py)
     1. 下载模型 → staging → 第一次打包 → 计算 CRC32/SHA256
     2. 写入完整 Manifest 到 staging → 第二次打包 (含 Manifest)
     3. 生成 dist/ 输出 → 自校验
@@ -571,20 +716,10 @@ def build_engine_pack(fixture: bool = False, from_cache: bool = False) -> dict[s
 
     # ── Production redistribution gate ──
     if not fixture:
-        unverified = []
-        for e in _get_engines_for_build():
-            eid = e.get("engine_id", "?")
-            from model_catalog import get_engine_by_id
-
-            eng_def = get_engine_by_id(eid)
-            if eng_def and not eng_def.redistribution_verified:
-                unverified.append(eid)
-        if unverified:
+        redistribution_errors = validate_redistribution_readiness()
+        if redistribution_errors:
             raise RuntimeError(
-                f"Production build blocked: {len(unverified)} engine(s) have "
-                f"redistribution_verified=false: {', '.join(unverified)}\n"
-                "All engines must have redistribution_verified=true for production builds.\n"
-                "Use --fixture for test builds without redistribution verification."
+                "Production build blocked by redistribution validation:\n  " + "\n  ".join(redistribution_errors)
             )
 
     # 解析 Commit
@@ -619,6 +754,13 @@ def build_engine_pack(fixture: bool = False, from_cache: bool = False) -> dict[s
     else:
         download_real_models(staging)
 
+    if not fixture:
+        model_errors = validate_prepared_models(staging)
+        if model_errors:
+            raise RuntimeError("Prepared model validation FAILED:\n  " + "\n  ".join(model_errors))
+
+    copy_license_materials(staging)
+
     # ── 阶段 2: 构建文件清单 → 写入 Manifest (不含自身归档哈希) ──
     print("\n  [阶段 2/3] 构建文件清单 → 写入 Manifest ...")
 
@@ -641,8 +783,10 @@ def build_engine_pack(fixture: bool = False, from_cache: bool = False) -> dict[s
                 "hub": e["hub"],
                 "revision": e.get("revision"),
                 "target_path": e["target_path"],
+                "license": e["license"],
                 "model_repo": e.get("repo_id"),
                 "sub_models": e.get("sub_models", []),
+                "third_party_components": e.get("third_party_components", []),
             }
             for e in _get_engines_for_build()
         ],

--- a/packaging/portable/src/blc_portable/engine_pack/downloader.py
+++ b/packaging/portable/src/blc_portable/engine_pack/downloader.py
@@ -1,6 +1,6 @@
 """独立引擎模型缓存下载脚本。
 
-每个引擎独立下载到持久缓存目录 (build/model_cache/)。
+每个引擎独立下载到持久缓存目录 (.model_cache/)。
 支持断点续传，引擎间互不影响。完成后由 build_engine_pack.py 读取缓存构建 ZIP。
 
 用法:
@@ -51,6 +51,7 @@ def _load_engine_defs() -> list[dict[str, Any]]:
             "revision": e.resolved_revision if e.resolved_revision else None,
             "cache_dir": _engine_id_to_cache_dir(e.engine_id),
             "target_path": e.target_path,
+            "required_files": e.required_files,
             "size_hint": "N/A",
         }
         if e.sub_models:
@@ -61,6 +62,14 @@ def _load_engine_defs() -> list[dict[str, Any]]:
                     "name": s.target_subdir if s.target_subdir else s.repository.rsplit("/", 1)[-1],
                 }
                 for s in e.sub_models
+            ]
+        if e.third_party_components:
+            d["third_party_components"] = [
+                {
+                    "component_id": component.component_id,
+                    "target_subdir": component.target_subdir,
+                }
+                for component in e.third_party_components
             ]
         engines.append(d)
     return engines
@@ -103,6 +112,32 @@ def get_engine_size(engine_dir: Path) -> tuple[int, float]:
     return fc, ts / (1024**3)
 
 
+def validate_engine_cache(engine: dict[str, Any]) -> list[str]:
+    """校验单个引擎缓存是否符合当前锁文件。"""
+    errors: list[str] = []
+    engine_dir = get_engine_dir(engine)
+    if not engine_dir.is_dir():
+        return [f"缓存目录不存在: {engine_dir}"]
+
+    for required_file in engine.get("required_files", []):
+        required_path = engine_dir / str(required_file)
+        if not required_path.is_file() or required_path.stat().st_size == 0:
+            errors.append(f"必需文件缺失或为空: {required_file}")
+
+    for sub_model in engine.get("sub_models", []):
+        target_subdir = str(sub_model.get("name", ""))
+        subdir = engine_dir / target_subdir
+        if not subdir.is_dir() or not any(path.is_file() for path in subdir.rglob("*")):
+            errors.append(f"子模型目录缺失或为空: {target_subdir}")
+
+    for component in engine.get("third_party_components", []):
+        target_subdir = str(component.get("target_subdir", ""))
+        component_dir = engine_dir / target_subdir
+        if not component_dir.is_dir() or not any(path.is_file() for path in component_dir.rglob("*")):
+            errors.append(f"随附组件目录缺失或为空: {target_subdir}")
+    return errors
+
+
 def show_status() -> None:
     """显示所有引擎下载状态。"""
     print("=" * 60)
@@ -115,7 +150,8 @@ def show_status() -> None:
         fc, gb = get_engine_size(engine_dir)
         total_files += fc
         total_gb += gb
-        status = "[OK]" if fc > 0 and gb > 0.01 else "[--]"
+        cache_errors = validate_engine_cache(engine)
+        status = "[OK]" if not cache_errors else "[--]"
         extra = engine.get("size_hint", "")
         print(f"  [{status}] {engine['engine_name']}")
         print(f"         目录: {engine_dir}")
@@ -129,8 +165,6 @@ def download_engine(engine: dict[str, Any]) -> bool:
     :param engine: 引擎定义。
     :returns: True 成功。
     """
-    from modelscope.hub.snapshot_download import snapshot_download
-
     engine_dir = get_engine_dir(engine)
     engine_dir.mkdir(parents=True, exist_ok=True)
 
@@ -139,7 +173,7 @@ def download_engine(engine: dict[str, Any]) -> bool:
     hub = engine.get("hub", "modelscope")
 
     print(f"\n  [{engine['engine_id']}] {engine['engine_name']}")
-    print(f"  ModelScope ID: {model_id}")
+    print(f"  Model ID: {model_id}")
     if revision:
         print(f"  Revision: {revision}")
     print(f"  目标目录: {engine_dir}")
@@ -152,7 +186,20 @@ def download_engine(engine: dict[str, Any]) -> bool:
             kwargs["revision"] = str(revision)
 
         if hub == "modelscope":
+            from modelscope.hub.snapshot_download import snapshot_download
+
             snapshot_download(**kwargs)
+        elif hub == "huggingface":
+            from huggingface_hub import snapshot_download as hf_snapshot_download
+
+            hf_snapshot_download(
+                repo_id=model_id,
+                local_dir=str(engine_dir),
+                local_dir_use_symlinks=False,
+                revision=str(revision) if revision else None,
+            )
+        else:
+            raise ValueError(f"不支持的模型仓库类型: {hub}")
 
         # 子模型下载 (Paraformer)
         for sub in engine.get("sub_models", []):
@@ -174,6 +221,12 @@ def download_engine(engine: dict[str, Any]) -> bool:
 
     elapsed = time.time() - start
     fc, gb = get_engine_size(engine_dir)
+    cache_errors = validate_engine_cache(engine)
+    if cache_errors:
+        print(f"\n  [FAIL] 缓存校验失败 ({elapsed:.0f}s):")
+        for error in cache_errors:
+            print(f"    - {error}")
+        return False
     print(f"  [OK] 完成 ({elapsed:.0f}s): {fc} 文件, {gb:.2f} GB")
 
     # 更新状态
@@ -202,7 +255,7 @@ def main() -> None:
     print("  BiliLiveCut Engine Pack — 模型缓存下载")
     print(f"  目标引擎: {', '.join(targets)}")
     print(f"  缓存目录: {CACHE_DIR}")
-    print("  下载源: ModelScope (国内加速)")
+    print("  下载源: ModelScope + Hugging Face（固定 revision）")
     print("=" * 60)
 
     failed: list[str] = []
@@ -215,11 +268,14 @@ def main() -> None:
         state = load_state()
         if eid in state.get("downloaded", []):
             fc, gb = get_engine_size(get_engine_dir(engine))
-            if fc > 0 and gb > 0.01:
+            cache_errors = validate_engine_cache(engine)
+            if not cache_errors:
                 print(f"\n  [{eid}] 已缓存，跳过 ({fc} 文件, {gb:.2f} GB)")
                 continue
             else:
-                # 状态文件显示已下载但实际文件不存在，重置状态
+                print(f"\n  [{eid}] 缓存与当前锁文件不一致，将重新同步:")
+                for error in cache_errors:
+                    print(f"    - {error}")
                 state["downloaded"].remove(eid)
                 save_state(state)
 

--- a/packaging/portable/tests/test_engine_pack_production.py
+++ b/packaging/portable/tests/test_engine_pack_production.py
@@ -195,6 +195,43 @@ class TestEnginePackInfoFields:
         info = json.loads(_EP_INFO_PATH.read_text(encoding="utf-8"))
         assert set(info["expected_engine_ids"]) == {"whisper", "paraformer", "sensevoice", "funasr_nano"}
 
+    def test_external_manifest_matches_packaged_content_manifest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """外部内容 Manifest 必须与写入 ZIP 的版本逐字一致，且不得把自身加入文件清单。"""
+        from blc_portable.engine_pack import builder
+
+        dist_dir = tmp_path / "dist"
+        resources_dir = tmp_path / "resources"
+        monkeypatch.setattr(builder, "DIST_DIR", dist_dir)
+        monkeypatch.setattr(builder, "RESOURCES_DIR", resources_dir)
+
+        content_manifest = {
+            "schema_version": 4,
+            "engine_pack_version": "0.1.15.1-alpha",
+            "total_files": 1,
+            "fixture": True,
+            "engines": [],
+            "files": {"models/fixture/model.bin": {"size": 4, "sha256": "0" * 64}},
+        }
+        content_manifest_path = tmp_path / "engine-pack-manifest.json"
+        content_manifest_path.write_text(json.dumps(content_manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+        archive_path = tmp_path / "fixture.zip"
+        archive_path.write_bytes(b"fixture")
+
+        result = builder.write_output_files(
+            crc32_val="1234ABCD",
+            sha256_val="a" * 64,
+            archive_path=archive_path,
+            source_commit="1b47a0942b04efc1c11b11e1f74bc970f843f4c4",
+            content_manifest_path=content_manifest_path,
+            is_fixture=True,
+        )
+
+        assert (dist_dir / "engine-pack-manifest.json").read_bytes() == content_manifest_path.read_bytes()
+        assert result["file_count"] == 1
+        assert "engine-pack-manifest.json" not in content_manifest["files"]
+
 
 # ── 版本/API 兼容性 ────────────────────────────────────
 

--- a/packaging/portable/tests/test_engine_pack_production.py
+++ b/packaging/portable/tests/test_engine_pack_production.py
@@ -132,6 +132,20 @@ class TestFixtureImpersonationDetection:
         meta = ExternalMetadata()
         assert meta.artifact_class == "", "artifact_class default must be empty, not 'production'"
 
+    def test_builder_rejects_tiny_production_archive(self) -> None:
+        """正式构建器必须拒绝小体积占位包。"""
+        from blc_portable.engine_pack.builder import validate_production_metadata
+
+        errors = validate_production_metadata(
+            "ABCDEF01",
+            "a" * 64,
+            "b" * 64,
+            "c" * 64,
+            "d" * 40,
+            1024,
+        )
+        assert any("too small" in error for error in errors)
+
 
 # ── engine_pack_info.json 必需字段 ──────────────────────
 

--- a/packaging/portable/tests/test_model_consistency.py
+++ b/packaging/portable/tests/test_model_consistency.py
@@ -65,3 +65,72 @@ class TestModelCatalogSingleSource:
         content = downloader_py.read_text(encoding="utf-8")
         assert "_load_engine_defs" in content, "downloader.py does not use catalog loader"
         assert "ENGINES: list" not in content, "downloader.py still has independent ENGINES list"
+
+    def test_all_distributed_components_have_verified_license_evidence(self) -> None:
+        catalog = _load_lock()
+        required = {"name", "spdx", "source", "evidence_url", "license_file", "verified_at"}
+        for engine in catalog["engines"]:
+            components = [engine, *engine.get("sub_models", []), *engine.get("third_party_components", [])]
+            for component in components:
+                license_info = component.get("license", {})
+                assert required <= license_info.keys(), f"Incomplete license metadata: {component}"
+                assert license_info["redistribution_verified"] is True
+                license_path = _portable_dir / license_info["license_file"]
+                assert license_path.is_file(), f"Missing license file: {license_path}"
+
+    def test_production_redistribution_gate_passes(self) -> None:
+        from blc_portable.engine_pack.builder import validate_redistribution_readiness
+
+        assert validate_redistribution_readiness() == []
+
+    def test_license_materials_are_copied_into_pack(self, tmp_path: Path) -> None:
+        from blc_portable.engine_pack.builder import copy_license_materials
+
+        copy_license_materials(tmp_path)
+        assert (tmp_path / "licenses" / "THIRD_PARTY_NOTICES.md").is_file()
+        assert (tmp_path / "licenses" / "MIT.txt").is_file()
+        assert (tmp_path / "licenses" / "Apache-2.0.txt").is_file()
+
+    def test_prepared_models_accept_current_locked_layout(self, tmp_path: Path) -> None:
+        from blc_portable.engine_pack.builder import _get_engines_for_build, validate_prepared_models
+
+        for engine in _get_engines_for_build():
+            target = tmp_path / str(engine["target_path"])
+            target.mkdir(parents=True)
+            for required_file in engine.get("required_files", []):
+                required_path = target / str(required_file)
+                required_path.parent.mkdir(parents=True, exist_ok=True)
+                required_path.write_bytes(b"fixture")
+            for sub_model in engine.get("sub_models", []):
+                subdir = target / str(sub_model["target_subdir"])
+                subdir.mkdir(parents=True)
+                (subdir / "model.bin").write_bytes(b"fixture")
+            for component in engine.get("third_party_components", []):
+                component_dir = target / str(component["target_subdir"])
+                component_dir.mkdir(parents=True)
+                (component_dir / "config.json").write_text("{}", encoding="utf-8")
+
+        assert validate_prepared_models(tmp_path) == []
+
+    def test_prepared_models_reject_legacy_cam_plus_plus_path(self, tmp_path: Path) -> None:
+        from blc_portable.engine_pack.builder import _get_engines_for_build, validate_prepared_models
+
+        paraformer = next(engine for engine in _get_engines_for_build() if engine["engine_id"] == "paraformer")
+        target = tmp_path / str(paraformer["target_path"])
+        target.mkdir(parents=True)
+        for required_file in paraformer["required_files"]:
+            (target / str(required_file)).write_bytes(b"fixture")
+        for subdir_name in ("fsmn-vad", "ct-punc", "cam++"):
+            subdir = target / subdir_name
+            subdir.mkdir()
+            (subdir / "model.bin").write_bytes(b"fixture")
+
+        errors = validate_prepared_models(tmp_path)
+        assert any("campplus" in error for error in errors)
+
+    def test_fixture_uses_current_submodel_and_component_layout(self, tmp_path: Path) -> None:
+        from blc_portable.engine_pack.builder import build_fixture
+
+        build_fixture(tmp_path)
+        assert (tmp_path / "models" / "paraformer" / "campplus" / "model_metadata.json").is_file()
+        assert (tmp_path / "models" / "funasr_nano" / "Qwen3-0.6B" / "component_metadata.json").is_file()

--- a/packaging/portable/tests/test_model_consistency.py
+++ b/packaging/portable/tests/test_model_consistency.py
@@ -30,10 +30,19 @@ class TestModelCatalogSingleSource:
             rev = engine.get("resolved_revision", "")
             assert rev, f"Engine {engine['engine_id']}: resolved_revision empty"
             assert rev not in ("main", "master"), f"Engine {engine['engine_id']}: floating revision {rev}"
-            if engine["hub"] == "huggingface":
+            if engine["hub"] == "huggingface" or not rev.startswith("v"):
                 assert len(rev) == 40 and all(char in "0123456789abcdef" for char in rev), (
-                    f"Engine {engine['engine_id']}: Hugging Face revision must be a full commit: {rev}"
+                    f"Engine {engine['engine_id']}: revision must be a full commit or version tag: {rev}"
                 )
+
+    def test_master_only_modelscope_repositories_use_resolved_commits(self) -> None:
+        catalog = _load_lock()
+        expected = {
+            "sensevoice": "7bf452403abd7353a300cd760f7adae7701c92c1",
+            "funasr_nano": "05201c46f1c38592b1567f857c0d56eab3d0d8ef",
+        }
+        actual = {engine["engine_id"]: engine["resolved_revision"] for engine in catalog["engines"]}
+        assert {engine_id: actual[engine_id] for engine_id in expected} == expected
 
     def test_no_legacy_funasr_repo(self) -> None:
         catalog = _load_lock()

--- a/packaging/portable/tests/test_model_consistency.py
+++ b/packaging/portable/tests/test_model_consistency.py
@@ -30,6 +30,10 @@ class TestModelCatalogSingleSource:
             rev = engine.get("resolved_revision", "")
             assert rev, f"Engine {engine['engine_id']}: resolved_revision empty"
             assert rev not in ("main", "master"), f"Engine {engine['engine_id']}: floating revision {rev}"
+            if engine["hub"] == "huggingface":
+                assert len(rev) == 40 and all(char in "0123456789abcdef" for char in rev), (
+                    f"Engine {engine['engine_id']}: Hugging Face revision must be a full commit: {rev}"
+                )
 
     def test_no_legacy_funasr_repo(self) -> None:
         catalog = _load_lock()

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -58,12 +58,12 @@ class TestModelCatalogIsSingleSource:
         assert "/" in engine.repository
 
     def test_whisper_uses_correct_repository(self) -> None:
-        """Whisper 仓库不可变。"""
+        """Whisper 必须使用迁移后的规范仓库。"""
         from model_catalog import get_engine_by_id
 
         engine = get_engine_by_id("whisper")
         assert engine is not None
-        assert "mobiuslabsgmbh/faster-whisper-large-v3-turbo" in engine.repository
+        assert engine.repository == "dropbox-dash/faster-whisper-large-v3-turbo"
 
     def test_all_engines_have_resolved_revision(self) -> None:
         """所有引擎必须有 resolved_revision。"""


### PR DESCRIPTION
## 变更摘要

- 为正式 Engine Pack 增加再分发许可证门禁；许可证证据、来源、验证日期或随包许可证文件缺失时直接阻止生产构建。
- 修复 Hugging Face 下载缺口、旧缓存布局误复用，以及 Paraformer `cam++`/`campplus` 目录不一致问题。
- 将 Whisper 切换到迁移后的规范仓库，并固定为可解析的完整提交；将只有 `master` 的 SenseVoice、Fun-ASR Nano 固定为官方 Git 远端对应的完整提交 SHA。
- 修复 ZIP 内嵌 Manifest 与外部 Manifest 被重复生成成不同结构的问题；现在两者逐字一致，内容清单不再自引用，归档哈希由外部校验文件承载。
- 同步 Portable 文档、V0.1.15 收口说明、模型版本表和回归测试。

## 许可证与再分发信息

本 PR 将许可证材料一并写入 Engine Pack 的 `licenses/` 目录，并在 Manifest 中保留每个主模型、子模型及随附组件的许可证元数据。

- Whisper large-v3-turbo（CTranslate2 转换）及 OpenAI Whisper 原始权重：MIT。
  - 模型来源：https://huggingface.co/dropbox-dash/faster-whisper-large-v3-turbo
  - 原始项目：https://github.com/openai/whisper
- Paraformer-zh、FSMN-VAD、CT-Transformer 标点、CAM++、SenseVoiceSmall、Fun-ASR-Nano-2512：Apache-2.0。
  - ModelScope 来源：https://modelscope.cn/models
- Fun-ASR Nano 随附的 Qwen3-0.6B：Apache-2.0。
  - 许可证证据：https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/LICENSE

随包文件：

- `licenses/THIRD_PARTY_NOTICES.md`
- `licenses/MIT.txt`
- `licenses/Apache-2.0.txt`

许可证正文已与官方来源逐字校验：

- MIT SHA-256：`b5d65a59060e68c4ff940e1eddfa6f94b2d68fdf58ed7f4dd57721c997e35e9d`
- Apache-2.0 SHA-256：`cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30`

固定 revision：

- Whisper：`0a363e9161cbc7ed1431c9597a8ceaf0c4f78fcf`
- Paraformer：`v2.0.4`
- SenseVoice：`7bf452403abd7353a300cd760f7adae7701c92c1`
- Fun-ASR Nano：`05201c46f1c38592b1567f857c0d56eab3d0d8ef`

以上信息用于保存上游归属和许可证文本，不构成额外授权或法律意见。

## 验证结果

- `scripts/release_gate.py`：通过；Release Audit `39/39`，版本一致性、Ruff、Payload、主测试和 Portable 全测试全部通过。
- `check-manifest --no-build-isolation -v`：通过；363 个版本控制文件与 sdist 文件列表一致。
- Engine Pack 目标测试：通过。
- 正式 Engine Pack 从锁定 revision 直接下载构建，构建器自校验通过。
- 独立校验重新计算整包 SHA-256/CRC32，并逐一验证 97 个内容文件的大小与 SHA-256；ZIP CRC、安全路径、无符号链接、版本、构建提交、模型 revision、许可证元数据、`campplus` 与 Qwen3 布局均通过。

本地分发产物未提交到 Git：

- 文件：`BiliLiveCut-EnginePack-0.1.15.1-alpha.zip`
- 大小：`5,920,369,268` bytes
- SHA-256：`0c79fc19e3a62a32ac4de022138a9a39bcc0764f884ae71f35a30505cea306db`
- CRC32：`C1799094`
- 构建提交：`8ea3f7654ba71a5d3e9d7943784759c7e0437f41`

该 ZIP 大于 4 GB，分发和解压介质必须使用 NTFS 或 exFAT，不能使用 FAT32。
