### PR TITLE
修复 Engine Pack 在 Windows 旧代码页下的输出崩溃

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 修复
 
+- **release**: Engine Pack CLI 在入口统一配置 UTF-8 输出并保留不可编码字符的回退表示，修复 Windows runner 使用 `cp1252` 代码页时 Fixture 构建因中文日志触发 `UnicodeEncodeError`。
 - **login**: 系统 Chrome 与托管 Chromium 登录均显式启用 sandbox，并改为从独立 Playwright 上下文读取全部 Cookie 后按 Bilibili 域名边界筛选，修复新版 Chrome 下登录完成但无法捕获 Cookie 的问题。
 - **web**: 修复候选片段拒绝请求的模板字符串未闭合导致前端 ES Module 初始化中断、页面按钮全部失效，并增加全量静态 JavaScript 语法回归检查。
 - **portable**: Full 首次安装完成依赖后，`app.cli` 导入检查改为显式使用已安装的内容寻址 Runtime 源码，并在失败时保留原始 stdout/stderr。

--- a/packaging/portable/src/blc_portable/engine_pack/builder.py
+++ b/packaging/portable/src/blc_portable/engine_pack/builder.py
@@ -55,6 +55,19 @@ MIN_PRODUCTION_ARCHIVE_BYTES = 500 * 1024 * 1024
 HF_MIRROR = "https://hf-mirror.com"
 
 
+def _configure_console_encoding() -> None:
+    """将 CLI 输出切换到 UTF-8，避免旧版 Windows 代码页无法输出中文。"""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (OSError, TypeError, ValueError):
+            # 测试捕获器或嵌入式宿主可能不允许修改流配置；此时保留宿主设置。
+            continue
+
+
 # ── 四引擎定义 — 来自统一模型目录 ──────────────────────────
 # 所有模型定义现在唯一权威来源: packaging/portable/config/model_sources.lock.json
 # 通过 blc_portable.config.model_catalog 统一加载。
@@ -823,6 +836,7 @@ def main() -> int:
 
     :returns: 0 成功, 1 失败。
     """
+    _configure_console_encoding()
     try:
         fixture_mode = "--fixture" in sys.argv
         cache_mode = "--from-cache" in sys.argv
@@ -836,6 +850,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    fixture_mode = "--fixture" in sys.argv
-    cache_mode = "--from-cache" in sys.argv
-    build_engine_pack(fixture=fixture_mode, from_cache=cache_mode)
+    raise SystemExit(main())

--- a/packaging/portable/tests/test_engine_pack.py
+++ b/packaging/portable/tests/test_engine_pack.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import shutil
 import sys
@@ -27,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 if TYPE_CHECKING:
-    pass
+    from pytest import MonkeyPatch
 
 # 添加 portable 模块到路径 (与 test_portable.py 一致)
 _portable_dir = Path(__file__).resolve().parent.parent  # portable/
@@ -137,6 +138,41 @@ def fixture_engine_pack() -> Generator[Path, None, None]:
 
         shutil.rmtree(str(staging))
         yield zip_path
+
+
+class TestEnginePackConsole:
+    """Engine Pack CLI 控制台兼容性回归测试。"""
+
+    def test_main_reconfigures_legacy_console_before_output(self, monkeypatch: MonkeyPatch) -> None:
+        """cp1252 重定向流不得因中文状态或错误信息崩溃。"""
+        from blc_portable.engine_pack import builder
+
+        stdout_bytes = io.BytesIO()
+        stderr_bytes = io.BytesIO()
+        stdout = io.TextIOWrapper(stdout_bytes, encoding="cp1252", errors="strict")
+        stderr = io.TextIOWrapper(stderr_bytes, encoding="cp1252", errors="strict")
+
+        monkeypatch.setattr(sys, "stdout", stdout)
+        monkeypatch.setattr(sys, "stderr", stderr)
+        monkeypatch.setattr(sys, "argv", ["build_engine_pack.py", "--fixture"])
+
+        def fail_build_engine_pack(*, fixture: bool, from_cache: bool) -> dict[str, Any]:
+            assert fixture is True
+            assert from_cache is False
+            print("Fixture 模式")
+            raise RuntimeError("构建错误")
+
+        monkeypatch.setattr(builder, "build_engine_pack", fail_build_engine_pack)
+
+        assert builder.main() == 1
+        stdout.flush()
+        stderr.flush()
+
+        assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+        assert stderr.encoding.lower().replace("_", "-") == "utf-8"
+        output = stdout_bytes.getvalue().decode("utf-8")
+        assert "Fixture 模式" in output
+        assert "[错误] 构建错误" in output
 
 
 # ── Manifest 测试 ────────────────────────────────────────────


### PR DESCRIPTION
## 根因

Release run [29969864010](https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/29969864010) 的 `Smoke tests (Lite + Full)` 在 Windows runner 上使用 `cp1252` 控制台编码。Full Bundle 离线依赖安装已经成功，但 Fixture Engine Pack 构建输出中文状态文字时触发 `UnicodeEncodeError`；异常处理再次输出中文前缀后又触发同类错误，导致冒烟任务失败。

失败 job：[89090960714](https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/29969864010/job/89090960714)

## 修改

- 在 Engine Pack CLI 入口统一将 stdout/stderr 配置为 UTF-8，并为不可编码字符保留回退表示。
- 让脚本直接执行与模块入口统一经过 `main()`，避免绕过编码初始化和标准退出码。
- 增加 `cp1252` 状态输出与异常日志回归测试。
- 更新变更日志。

## 影响

仅修复 Engine Pack 构建命令的控制台输出兼容性；不改变公开 API、CLI 参数、配置格式或 Engine Pack 内容。

## 验证

- Engine Pack 相关测试：69 项通过。
- `cp1252` CLI 复现脚本：通过。
- Ruff 检查与格式检查：通过。
- `python scripts/release_gate.py`：全部通过；发布审计 41 PASS、0 WARN、0 FAIL。
- `git diff --check`：通过。

## 许可证

本次修改未新增或升级生产依赖，未引入新的第三方代码、模型或资源，因此不产生新的许可证或再分发义务。
