### PR TITLE
修复 Release 与 macOS CI 的原生构建回归

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install build tools
         run: |
-          python -m pip install --upgrade pip build wheel check-manifest twine
+          python -m pip install --upgrade pip build wheel check-manifest twine Cython==3.2.8
 
       - name: Validate source manifest
         run: check-manifest --no-build-isolation --ignore ".cursor/*,.cursor/rules/*,.dockerignore"

--- a/packaging/portable/src/blc_portable/payload/builder.py
+++ b/packaging/portable/src/blc_portable/payload/builder.py
@@ -258,7 +258,7 @@ def _compile_and_copy_native_modules(staging_dir: Path) -> dict[str, bool]:
         300,
     )
 
-    missing_required = [name for name in ("c", "cython") if not results[name]]
+    missing_required = [name for name in ("c", "cython", "rust") if not results[name]]
     if missing_required:
         raise RuntimeError(f"Windows Payload 缺少必需原生模块：{', '.join(missing_required)}")
 

--- a/packaging/portable/tests/test_payload_native.py
+++ b/packaging/portable/tests/test_payload_native.py
@@ -50,7 +50,24 @@ def test_payload_native_build_rejects_false_success(monkeypatch: MonkeyPatch, tm
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
-    with pytest.raises(RuntimeError, match="缺少必需原生模块：c, cython"):
+    with pytest.raises(RuntimeError, match="缺少必需原生模块：c, cython, rust"):
+        builder._compile_and_copy_native_modules(tmp_path / "staging")
+
+
+def test_payload_native_build_requires_rust(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """Release 契约要求 Rust 时，构建器不得把 Rust 编译失败当作成功。"""
+    builder, analysis_dir = _prepare_builder(monkeypatch, tmp_path)
+
+    def fake_run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+        script_name = Path(command[1]).name
+        if script_name == "setup_c.py":
+            (analysis_dir / "_c_speedups.cp312-win_amd64.pyd").write_bytes(b"c")
+        elif script_name == "setup.py":
+            (analysis_dir / "_speedups_round2.cp312-win_amd64.pyd").write_bytes(b"cython")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(RuntimeError, match="缺少必需原生模块：rust"):
         builder._compile_and_copy_native_modules(tmp_path / "staging")
 
 

--- a/tests/unit/test_release_tooling.py
+++ b/tests/unit/test_release_tooling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -60,6 +61,29 @@ def test_rust_build_uses_current_python_interpreter() -> None:
     assert 'env.setdefault("PYO3_PYTHON", sys.executable)' in source
 
 
+def test_rust_build_uses_exact_windows_platform_match() -> None:
+    """darwin 不得因名称包含 win 而被误判为 Windows。"""
+    from tools.native import build_rust
+
+    assert build_rust._extension_suffix("win32") == ".pyd"
+    assert build_rust._extension_suffix("darwin") == ".so"
+    assert build_rust._extension_suffix("linux") == ".so"
+
+
+def test_rust_build_reconfigures_console_to_utf8() -> None:
+    """Windows runner 的 cp1252 文本流必须能安全输出中文日志。"""
+    from tools.native import build_rust
+
+    output = io.BytesIO()
+    stream = io.TextIOWrapper(output, encoding="cp1252", errors="strict")
+    build_rust._configure_stream_encoding(stream)
+    stream.write("Rust 加速模块编译")
+    stream.flush()
+
+    assert stream.encoding.lower() == "utf-8"
+    assert output.getvalue().decode("utf-8") == "Rust 加速模块编译"
+
+
 def test_rust_build_streams_cargo_output(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Cargo 构建继承控制台输出，不再缓存到进程结束。"""
     from tools.native import build_rust
@@ -103,6 +127,20 @@ def test_windows_payload_jobs_run_on_windows_and_verify_native_modules() -> None
     assert "Missing Windows native modules" in release_source
     assert "Foreign native modules in Windows Payload" in release_source
     assert "Full Bundle native acceleration OK" in release_source
+
+
+def test_source_manifest_job_installs_pinned_cython() -> None:
+    """禁用构建隔离的 source manifest 校验必须预装固定版本 Cython。"""
+    release_workflow = yaml.safe_load(
+        (run_ruff.REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    )
+    steps = release_workflow["jobs"]["build-sdist"]["steps"]
+    install_step = next(step for step in steps if step.get("name") == "Install build tools")
+
+    assert "Cython==3.2.8" in install_step["run"]
+    assert "--no-build-isolation" in next(
+        step["run"] for step in steps if step.get("name") == "Validate source manifest"
+    )
 
 
 def test_windows_c_extension_compiles_utf8_source() -> None:

--- a/tools/native/build_rust.py
+++ b/tools/native/build_rust.py
@@ -20,12 +20,37 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import TextIO
 
 _HERE = Path(__file__).resolve().parent
 # tools/native/ → 仓库根目录
 _REPO_ROOT = _HERE.parent.parent
 RUST_SRC = _REPO_ROOT / "tools" / "native" / "rust"
 TARGET_DIR = _REPO_ROOT / "app" / "analysis"
+
+
+def _configure_stream_encoding(stream: TextIO) -> None:
+    """将可重配置文本流切换为 UTF-8，并为不可编码字符保留转义回退。"""
+    reconfigure = getattr(stream, "reconfigure", None)
+    if not callable(reconfigure):
+        return
+    try:
+        reconfigure(encoding="utf-8", errors="backslashreplace")
+    except (OSError, TypeError, ValueError):
+        # pytest 捕获器或嵌入式宿主可能不允许修改流配置，此时保留宿主设置。
+        return
+
+
+def _configure_console_encoding() -> None:
+    """统一 Rust 构建 CLI 的控制台编码，兼容 Windows runner 的 cp1252。"""
+    for stream in (sys.stdout, sys.stderr):
+        _configure_stream_encoding(stream)
+
+
+def _extension_suffix(platform: str | None = None) -> str:
+    """返回目标平台的 Python 原生扩展后缀。"""
+    current_platform = sys.platform if platform is None else platform
+    return ".pyd" if current_platform == "win32" else ".so"
 
 
 def check_rust() -> bool:
@@ -93,7 +118,7 @@ def build() -> bool:
     print("  [build_rust] 编译成功")
 
     # 查找产物 (.pyd, .so, .dll)
-    ext = ".pyd" if "win" in sys.platform else ".so"
+    ext = _extension_suffix()
     build_dir = RUST_SRC / "target" / "release"
     candidates = list(build_dir.glob(f"_rust_cluster*{ext}"))
     # 也匹配 .dll (Windows Rust 默认输出)
@@ -121,6 +146,7 @@ def main() -> int:
 
     :returns: 0 = 成功, 1 = 失败。
     """
+    _configure_console_encoding()
     print("=" * 60)
     print("  BiliLiveCut Rust 加速模块编译")
     print(f"  仓库根目录: {_REPO_ROOT}")


### PR DESCRIPTION
## 根因

- Rust 构建脚本使用 `"win" in sys.platform` 判断 Windows，导致 `darwin` 被误判并查找 `.pyd`。
- Windows runner 默认 `cp1252` 输出编码，Rust CLI 在调用 cargo 前打印中文时触发 `UnicodeEncodeError`。
- Windows Payload 构建器将 Rust 视为可选模块，但后续 Release 契约要求 `_rust_cluster.pyd`，造成延迟失败。
- 源码包 job 使用 `check-manifest --no-build-isolation`，却未预装 `pyproject.toml` 新增的 `Cython==3.2.8` 构建依赖。

## 修改

- 精确使用 `sys.platform == "win32"` 选择 Windows 扩展后缀。
- Rust CLI 启动时将可重配置输出流切换为 UTF-8，并保留不可编码字符的回退表示。
- 将 C、Cython、Rust 三个模块统一纳入 Windows Payload 必需契约，缺失时立即失败。
- 在 Release 的 source manifest job 中显式安装固定版本 Cython。
- 增加 darwin、cp1252、Rust 缺失和无隔离 Cython 依赖回归测试。

## 验证

- 目标回归测试：15 项全部通过。
- 强制 `PYTHONIOENCODING=cp1252` 执行 Rust CLI：通过。
- `check-manifest --no-build-isolation`：通过。
- Windows Payload：183 个文件，C/Cython/Rust 齐全，无 `.so`/`.dll` 污染。
- `python scripts/release_gate.py`：全部通过，包括 41 项发布审计、版本一致性、Ruff、Payload 可复现构建、主测试和 Portable 全测试。
- `git diff --check`：通过。

## 影响

不改变版本号、公开接口、配置格式或业务行为，仅修复 CI/Release 构建链路并让缺失原生模块更早失败。
