### PR TITLE
修复 Release 冒烟测试无法解析固定源码基线

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,6 +415,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Download Lite EXE
         uses: actions/download-artifact@v4

--- a/packaging/portable/tests/test_release_fixture.py
+++ b/packaging/portable/tests/test_release_fixture.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 _PORTABLE_DIR = Path(__file__).resolve().parent.parent
 _PROJ_ROOT = _PORTABLE_DIR.parent.parent
 
@@ -16,6 +18,17 @@ def test_release_workflow_has_smoke_tests() -> None:
     assert "--version" in content, "Release workflow missing Lite EXE --version smoke test"
     assert "--doctor" in content, "Release workflow missing Lite EXE --doctor smoke test"
     assert "--diagnose" not in content, "Release workflow calls an unsupported launcher argument"
+
+
+def test_release_smoke_checkout_includes_source_baseline_history() -> None:
+    """Fixture Engine Pack 构建前必须拉取固定源码基线所在的完整历史。"""
+    release_yml = _PROJ_ROOT / ".github" / "workflows" / "release.yml"
+    workflow = yaml.safe_load(release_yml.read_text(encoding="utf-8"))
+    checkout = next(
+        step for step in workflow["jobs"]["smoke-test"]["steps"] if step.get("uses") == "actions/checkout@v4"
+    )
+
+    assert checkout.get("with", {}).get("fetch-depth") == 0
 
 
 def test_release_workflow_has_tag_validation() -> None:


### PR DESCRIPTION
## 根因

Release 的 `smoke-test` job 使用 `actions/checkout@v4` 默认浅克隆。Fixture Engine Pack 构建需要解析固定源码基线 `f2c291d`，但该提交不在深度为 1 的对象库中，因此 Full Bundle 前置检查全部通过后，`build_engine_pack.py --fixture` 仍因无法解析 Commit 而失败。

## 修改

- 为 `smoke-test` 的 checkout 设置 `fetch-depth: 0`，确保固定源码基线可解析。
- 增加结构化回归测试，约束该 job 必须保留完整历史 checkout。

## 验证

- `pytest packaging/portable/tests/test_release_fixture.py tests/unit/test_release_tooling.py -q`：25 项通过。
- `scripts/release_gate.py`：完整通过；发布审计 41/41、版本一致性、Ruff、Payload 183 文件契约、主测试集及 Portable 测试集均通过。
- `git diff --check`：通过。

## 影响

仅修正 GitHub Release 冒烟测试的仓库检出深度，不修改版本号、公开接口、业务逻辑或发布制品内容。
