### PR TITLE
修复 Windows Smoke 中冻结 Launcher 的中文输出崩溃

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 修复
 
+- **portable**: 冻结 Launcher 入口统一将 stdout/stderr 切换为 UTF-8，并为不可编码字符保留回退表示，修复 Windows `cp1252` 控制台在 Engine Pack 安装进度输出中文时崩溃。
 - **portable/native**: Windows Payload 改为在 Windows runner 构建，并以当前 Python ABI 的实际 `.pyd` 文件作为成功条件；禁止将 Linux `.so` 或旧 ABI 模块装入 Windows Portable，Full 离线冒烟会验证 C、Cython 与 Rust 后端均已加载。
 - **native**: Cython 第二轮加速的时间戳和长度/索引统一使用双精度与 `Py_ssize_t`，修复 Unix epoch 分桶及长时间轴 SRT 与 Python fallback 不一致；Rust 构建改为实时显示 Cargo 输出。
 - **subtitle**: `line_gap_ms` 现在按词间停顿阈值执行字幕断句，修复字幕模板配置已保存但不生效。

--- a/packaging/portable/src/blc_portable/launcher/main.py
+++ b/packaging/portable/src/blc_portable/launcher/main.py
@@ -46,6 +46,19 @@ FFMPEG_WIN_URL = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest
 # -- Resource paths ──────────────────────────────────────────────
 
 
+def _configure_console_encoding() -> None:
+    """将 Launcher 输出切换为 UTF-8，避免旧版 Windows 代码页无法输出中文。"""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (OSError, TypeError, ValueError):
+            # 测试捕获器或嵌入式宿主可能不允许修改流配置；此时保留宿主设置。
+            continue
+
+
 def get_bundled_resource_path(rel: str) -> Path | None:
     """Get bundled resource path, compatible with PyInstaller and normal run。
 
@@ -965,6 +978,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     :param argv: 命令行参数列表 (None 使用 sys.argv)。
     :returns: 退出码 (0 成功, 非零失败)。
     """
+    _configure_console_encoding()
     parser = build_parser()
 
     try:

--- a/packaging/portable/tests/test_launcher_entrypoint.py
+++ b/packaging/portable/tests/test_launcher_entrypoint.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import argparse
 import ast
+import io
 import runpy
 import sys
 from pathlib import Path
@@ -44,6 +46,31 @@ def test_launcher_version_python_entrypoint() -> None:
 
     result = main(["--version"])
     assert result == 0, f"main(['--version']) should return 0, got {result}"
+
+
+def test_launcher_reconfigures_legacy_console_before_run(monkeypatch: MonkeyPatch) -> None:
+    """冻结入口必须先切换输出编码，再进入可能打印中文的 Launcher 流程。"""
+    from blc_portable.launcher import main as launcher_module  # noqa: E402
+
+    stdout_bytes = io.BytesIO()
+    stderr_bytes = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_bytes, encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(stderr_bytes, encoding="cp1252", errors="strict")
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    def fake_run_launcher(_args: argparse.Namespace) -> int:
+        print("Engine Pack 校验通过")
+        return 0
+
+    monkeypatch.setattr(launcher_module, "run_launcher", fake_run_launcher)
+
+    assert launcher_module.main([]) == 0
+    stdout.flush()
+    stderr.flush()
+    assert stdout.encoding.lower().replace("-", "") == "utf8"
+    assert stderr.encoding.lower().replace("-", "") == "utf8"
+    assert "Engine Pack 校验通过" in stdout_bytes.getvalue().decode("utf-8")
 
 
 def test_launcher_help_python_entrypoint() -> None:

--- a/tests/test_launcher_entrypoint.py
+++ b/tests/test_launcher_entrypoint.py
@@ -42,6 +42,8 @@ def test_launcher_version_python_entrypoint() -> None:
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="strict",
         timeout=15,
     )
     assert result.returncode == 0, f"--version 应返回 0，实际 {result.returncode}: {result.stderr}"
@@ -57,6 +59,8 @@ def test_launcher_help_python_entrypoint() -> None:
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="strict",
         timeout=15,
     )
     assert result.returncode == 0, f"--help 应返回 0，实际 {result.returncode}: {result.stderr}"
@@ -73,6 +77,8 @@ def test_launcher_invalid_args_return_nonzero() -> None:
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="strict",
         timeout=15,
     )
     # argparse recognizes unknown args and exits with 2


### PR DESCRIPTION
## 问题

Release workflow 的 `Smoke tests (Lite + Full)` 在 Full Bundle 使用 Fixture Engine Pack 时失败：冻结版 Launcher 的当前进程仍沿用 Windows `cp1252` 输出流，安装器打印“Engine Pack 校验通过”等中文进度时触发 `UnicodeEncodeError`。

失败任务：<https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/29979908703/job/89120929438>

## 修改

- 在 Launcher 可调用入口解析参数前，将当前进程的 `stdout` / `stderr` 重配置为 UTF-8，并使用 `backslashreplace` 处理极端不可编码字符。
- 保留 `PYTHONIOENCODING`，继续约束 Launcher 启动的子进程编码。
- 增加 `cp1252` 控制台回归测试，真实覆盖进入 Launcher 流程后输出 Engine Pack 中文状态的场景。
- 将跨进程入口测试显式按 UTF-8 解码，避免测试宿主按本地 `GBK` 误读 UTF-8 输出。
- 同步更新 V0.1.15.2 Alpha 变更记录。

## 影响

修复 Windows 冻结 Launcher 在 Engine Pack 安装阶段的崩溃；不改变公开 API、CLI 参数、配置格式或模型内容。

## 验证

- 目标回归：40 项通过。
- `python scripts/run_ruff.py check`：通过。
- `python scripts/run_ruff.py format`：通过。
- `python scripts/release_gate.py`：全部通过；发布审计 41 PASS / 0 WARN / 0 FAIL，版本一致，Payload 合约 183 个文件，主测试与 Portable 测试均通过。
- `git diff --check`：通过。

## 许可证

本修复未新增或升级任何生产依赖，也未引入新的第三方代码或许可证义务。
