### PR TITLE
补齐全部 Portable 入口的 Windows 控制台编码保护

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 修复
 
-- **portable**: 冻结 Launcher 入口统一将 stdout/stderr 切换为 UTF-8，并为不可编码字符保留回退表示，修复 Windows `cp1252` 控制台在 Engine Pack 安装进度输出中文时崩溃。
+- **portable**: Launcher、Engine Pack 构建/下载、Lite/Full、Payload 与旧版 Bundle 等全部 Portable CLI 入口统一将 stdout/stderr 切换为 UTF-8，并为不可编码字符保留回退表示，修复 Windows `cp1252` 控制台输出中文时直接崩溃或误报构建失败。
 - **portable/native**: Windows Payload 改为在 Windows runner 构建，并以当前 Python ABI 的实际 `.pyd` 文件作为成功条件；禁止将 Linux `.so` 或旧 ABI 模块装入 Windows Portable，Full 离线冒烟会验证 C、Cython 与 Rust 后端均已加载。
 - **native**: Cython 第二轮加速的时间戳和长度/索引统一使用双精度与 `Py_ssize_t`，修复 Unix epoch 分桶及长时间轴 SRT 与 Python fallback 不一致；Rust 构建改为实时显示 Cargo 输出。
 - **subtitle**: `line_gap_ms` 现在按词间停顿阈值执行字幕断句，修复字幕模板配置已保存但不生效。

--- a/packaging/portable/src/blc_portable/builders/common.py
+++ b/packaging/portable/src/blc_portable/builders/common.py
@@ -36,6 +36,8 @@ import zipfile
 from datetime import UTC, datetime
 from pathlib import Path
 
+from blc_portable.console import configure_console_encoding
+
 # faster-whisper 的 large-v3-turbo(CTranslate2 转换版)。
 # 该别名在 faster-whisper 的 _MODELS 中映射到此仓库。
 MODEL_REPO = "mobiuslabsgmbh/faster-whisper-large-v3-turbo"
@@ -654,6 +656,7 @@ def run_check(is_build: bool = False) -> bool:
 
 def main() -> None:
     """解析参数并按需执行打包步骤。"""
+    configure_console_encoding()
     parser = argparse.ArgumentParser(description="BiliLiveCut 即插即用版打包器")
     parser.add_argument("--skip-model", action="store_true", help="跳过模型下载")
     parser.add_argument("--skip-wheels", action="store_true", help="跳过依赖封装")

--- a/packaging/portable/src/blc_portable/builders/full.py
+++ b/packaging/portable/src/blc_portable/builders/full.py
@@ -17,6 +17,8 @@ import zipfile
 import zlib
 from pathlib import Path
 
+from blc_portable.console import configure_console_encoding
+
 PORTABLE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 PROJECT_ROOT = PORTABLE_DIR.parent.parent
 DIST_DIR = PORTABLE_DIR / "dist" / "full"
@@ -315,6 +317,7 @@ def main() -> int:
 
     :returns: 0 on success, 1 on failure.
     """
+    configure_console_encoding()
     try:
         build_full_bundle()
         return 0
@@ -329,4 +332,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    build_full_bundle()
+    raise SystemExit(main())

--- a/packaging/portable/src/blc_portable/builders/lite.py
+++ b/packaging/portable/src/blc_portable/builders/lite.py
@@ -18,6 +18,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from blc_portable.console import configure_console_encoding
+
 PORTABLE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 PROJECT_ROOT = PORTABLE_DIR.parent.parent
 SPEC_FILE = PORTABLE_DIR / "specs" / "portable_launcher.spec"
@@ -301,6 +303,7 @@ def main(argv: list[str] | None = None) -> int:
 
     :returns: 0 成功, 1 失败。
     """
+    configure_console_encoding()
     parser = argparse.ArgumentParser(description="Build the BiliLiveCut Portable Lite executable")
     parser.add_argument(
         "--without-engine-pack",

--- a/packaging/portable/src/blc_portable/console.py
+++ b/packaging/portable/src/blc_portable/console.py
@@ -1,0 +1,18 @@
+"""Portable 命令行入口的控制台兼容性工具。"""
+
+from __future__ import annotations
+
+import sys
+
+
+def configure_console_encoding() -> None:
+    """将当前进程输出切换为 UTF-8，避免旧版 Windows 代码页无法输出中文。"""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (OSError, TypeError, ValueError):
+            # 测试捕获器或嵌入式宿主可能不允许修改流配置；此时保留宿主设置。
+            continue

--- a/packaging/portable/src/blc_portable/engine_pack/builder.py
+++ b/packaging/portable/src/blc_portable/engine_pack/builder.py
@@ -36,6 +36,8 @@ import zlib
 from pathlib import Path
 from typing import Any
 
+from blc_portable.console import configure_console_encoding
+
 # ── 常量 ───────────────────────────────────────────────────
 
 PORTABLE_DIR = Path(__file__).resolve().parent.parent.parent.parent
@@ -53,19 +55,6 @@ CHUNK_SIZE = 8 * 1024 * 1024
 MIN_PRODUCTION_ARCHIVE_BYTES = 500 * 1024 * 1024
 
 HF_MIRROR = "https://hf-mirror.com"
-
-
-def _configure_console_encoding() -> None:
-    """将 CLI 输出切换到 UTF-8，避免旧版 Windows 代码页无法输出中文。"""
-    for stream in (sys.stdout, sys.stderr):
-        reconfigure = getattr(stream, "reconfigure", None)
-        if not callable(reconfigure):
-            continue
-        try:
-            reconfigure(encoding="utf-8", errors="backslashreplace")
-        except (OSError, TypeError, ValueError):
-            # 测试捕获器或嵌入式宿主可能不允许修改流配置；此时保留宿主设置。
-            continue
 
 
 # ── 四引擎定义 — 来自统一模型目录 ──────────────────────────
@@ -836,7 +825,7 @@ def main() -> int:
 
     :returns: 0 成功, 1 失败。
     """
-    _configure_console_encoding()
+    configure_console_encoding()
     try:
         fixture_mode = "--fixture" in sys.argv
         cache_mode = "--from-cache" in sys.argv

--- a/packaging/portable/src/blc_portable/engine_pack/downloader.py
+++ b/packaging/portable/src/blc_portable/engine_pack/downloader.py
@@ -20,6 +20,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from blc_portable.console import configure_console_encoding
+
 PORTABLE_DIR = Path(__file__).resolve().parent.parent.parent.parent
 CACHE_DIR = PORTABLE_DIR / ".model_cache"
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -241,6 +243,7 @@ def download_engine(engine: dict[str, Any]) -> bool:
 
 def main() -> None:
     """主入口。"""
+    configure_console_encoding()
     if "--status" in sys.argv or "-s" in sys.argv:
         show_status()
         return

--- a/packaging/portable/src/blc_portable/launcher/main.py
+++ b/packaging/portable/src/blc_portable/launcher/main.py
@@ -24,6 +24,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from blc_portable.console import configure_console_encoding
+
 # -- Constants ──────────────────────────────────────────────────
 APP_NAME = "BiliLiveCut"
 VERSION = "V0.1.15.2 Alpha"
@@ -44,19 +46,6 @@ FFMPEG_WIN_URL = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest
 
 
 # -- Resource paths ──────────────────────────────────────────────
-
-
-def _configure_console_encoding() -> None:
-    """将 Launcher 输出切换为 UTF-8，避免旧版 Windows 代码页无法输出中文。"""
-    for stream in (sys.stdout, sys.stderr):
-        reconfigure = getattr(stream, "reconfigure", None)
-        if not callable(reconfigure):
-            continue
-        try:
-            reconfigure(encoding="utf-8", errors="backslashreplace")
-        except (OSError, TypeError, ValueError):
-            # 测试捕获器或嵌入式宿主可能不允许修改流配置；此时保留宿主设置。
-            continue
 
 
 def get_bundled_resource_path(rel: str) -> Path | None:
@@ -978,7 +967,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     :param argv: 命令行参数列表 (None 使用 sys.argv)。
     :returns: 退出码 (0 成功, 非零失败)。
     """
-    _configure_console_encoding()
+    configure_console_encoding()
     parser = build_parser()
 
     try:

--- a/packaging/portable/src/blc_portable/payload/builder.py
+++ b/packaging/portable/src/blc_portable/payload/builder.py
@@ -20,6 +20,8 @@ import sysconfig
 import zipfile
 from pathlib import Path
 
+from blc_portable.console import configure_console_encoding
+
 from .manifest import (
     RELEASE_VERSION,
     SOURCE_COMMIT_FULL,
@@ -438,6 +440,7 @@ def build_payload(
 
 def _run_build_payload_main() -> None:
     """CLI entry point."""
+    configure_console_encoding()
     logging.basicConfig(level=logging.INFO, format="[%(name)s] %(message)s")
 
     try:
@@ -458,6 +461,8 @@ def main() -> int:
 
     :returns: 0 success, 1 failure.
     """
+    configure_console_encoding()
+
     import argparse as _argparse
 
     parser = _argparse.ArgumentParser(description="Build Payload")

--- a/packaging/portable/tests/test_console_encoding.py
+++ b/packaging/portable/tests/test_console_encoding.py
@@ -1,0 +1,101 @@
+"""Portable 命令行入口的 Windows 旧代码页兼容性测试。"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+_PORTABLE_DIR = Path(__file__).resolve().parent.parent
+_SRC_DIR = _PORTABLE_DIR / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+
+def _install_legacy_console(monkeypatch: MonkeyPatch) -> tuple[io.BytesIO, io.TextIOWrapper, io.TextIOWrapper]:
+    """安装严格 cp1252 输出流并返回底层缓冲区。"""
+    stdout_bytes = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_bytes, encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    return stdout_bytes, stdout, stderr
+
+
+@pytest.mark.parametrize(
+    ("module_name", "action_name", "argv", "passes_argv"),
+    (
+        ("blc_portable.engine_pack.downloader", "show_status", ["download_engines.py", "--status"], False),
+        ("blc_portable.builders.lite", "build_exe", ["build_exe.py"], True),
+        ("blc_portable.builders.full", "build_full_bundle", ["build_full_bundle.py"], False),
+        ("blc_portable.payload.builder", "build_payload", ["build_payload.py"], False),
+        ("blc_portable.builders.common", "copy_source", ["build_bundle.py", "--only-source"], False),
+    ),
+)
+def test_portable_cli_entrypoints_reconfigure_legacy_console(
+    monkeypatch: MonkeyPatch,
+    module_name: str,
+    action_name: str,
+    argv: list[str],
+    passes_argv: bool,
+) -> None:
+    """全部 Portable CLI 必须先切换 UTF-8，再执行可能输出中文的操作。"""
+    module: ModuleType = importlib.import_module(module_name)
+    stdout_bytes, stdout, stderr = _install_legacy_console(monkeypatch)
+    monkeypatch.setattr(sys, "argv", argv)
+
+    def emit_chinese(*_args: object, **_kwargs: object) -> None:
+        print("模型状态")
+
+    monkeypatch.setattr(module, action_name, emit_chinese)
+    entrypoint: Callable[..., object] = module.main
+
+    result = entrypoint([]) if passes_argv else entrypoint()
+    stdout.flush()
+    stderr.flush()
+
+    assert result in (None, 0)
+    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+    assert stderr.encoding.lower().replace("_", "-") == "utf-8"
+    assert "模型状态" in stdout_bytes.getvalue().decode("utf-8")
+
+
+def test_payload_module_entrypoint_reconfigures_legacy_console(monkeypatch: MonkeyPatch) -> None:
+    """Payload 的模块直执行入口也必须保护包含中文路径的构建报告。"""
+    from blc_portable.payload import builder
+
+    stdout_bytes, stdout, stderr = _install_legacy_console(monkeypatch)
+
+    def fake_build_payload() -> dict[str, object]:
+        return {
+            "zip_path": "模型/源码包.zip",
+            "manifest_path": "模型/manifest.json",
+            "payload_file_count": 1,
+            "payload_sha256": "a" * 64,
+            "verified_reproducible": True,
+        }
+
+    monkeypatch.setattr(builder, "build_payload", fake_build_payload)
+
+    builder._run_build_payload_main()
+    stdout.flush()
+    stderr.flush()
+
+    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+    assert "模型/源码包.zip" in stdout_bytes.getvalue().decode("utf-8")
+
+
+def test_full_module_guard_uses_console_safe_main() -> None:
+    """Full 模块直执行不得绕过带编码初始化的 callable main。"""
+    source = (_SRC_DIR / "blc_portable" / "builders" / "full.py").read_text(encoding="utf-8")
+
+    assert 'if __name__ == "__main__":\n    raise SystemExit(main())' in source


### PR DESCRIPTION
## 背景

PR #16 修复了冻结 Launcher 在 Windows `cp1252` 控制台打印 Engine Pack 中文进度时的崩溃。本 PR 在其合并后继续完成仓库级 Portable 入口审计，处理其余可复现的同源问题。

## 审计结果

在严格 `cp1252` 重定向流中逐入口复现后确认：

- Engine Pack 下载器与旧版 Bundle 工具会直接抛出 `UnicodeEncodeError`。
- Lite、Full 与 Payload 构建入口会把中文编码异常捕获为普通构建异常，表现为误报构建失败。
- Full 模块直执行路径绕过了带错误处理的 callable `main()`。
- Launcher 启动的 `app.cli` 子进程已继承 `PYTHONIOENCODING=utf-8`，无需重复修改业务 CLI。

## 修改

- 新增 Portable 内部共享控制台初始化器，统一将当前进程 `stdout` / `stderr` 重配置为 UTF-8，并使用 `backslashreplace` 处理极端不可编码字符。
- 覆盖 Launcher、Engine Pack 构建器/下载器、Lite、Full、Payload 与旧版 Bundle 共 7 类入口。
- Full 模块直执行改为进入同一 callable `main()`，不再绕过编码初始化与统一退出码处理。
- 保留 Payload 原有模块直执行成功报告，并单独加入编码初始化。
- 增加完整旧代码页入口矩阵回归，覆盖直接崩溃和隐蔽失败两类路径。
- 同步扩充 V0.1.15.2 Alpha 变更记录。

## 兼容性

不改变公开 API、CLI 参数、配置格式、模型内容或正常成功行为。仅统一 Portable 工具的控制台输出编码与异常路径。

## 验证

- `cp1252` 入口矩阵及相关目标测试：54 项通过。
- `python scripts/run_ruff.py check`：通过，包含新增文件，共 289 个 Python 文件。
- `python scripts/run_ruff.py format`：通过。
- `python scripts/release_gate.py`：前后两轮均全部通过；发布审计 41 PASS / 0 WARN / 0 FAIL，版本一致，Payload 合约 183 个文件，主测试与 Portable 测试全部通过。
- 实际构建 Lite EXE：通过，大小 59.7 MB。
- PyInstaller 依赖图：确认收集 `blc_portable.console`。
- 冻结 Lite EXE `--version` / `--help` 重定向冒烟：通过。
- Lite EXE SHA-256 与 CRC32 独立复算：与发布清单一致。
- `git diff --check`：通过。

本地缺少 Full 构建所需的 `portable-python`、离线 wheels 与 FFmpeg 素材，因此未伪造 Full Bundle 本地构建；Full 入口已由严格 `cp1252` 行为测试覆盖，完整制品构建由 GitHub Release workflow 验证。

## 许可证

本 PR 未新增或升级生产依赖，未引入新的第三方代码或许可证义务。
