### PR TITLE
修复 Release 预发布标签大小写兼容

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,19 @@ jobs:
           fi
           echo "Validating tag: $TAG_INPUT"
 
-          # Must match the complete release version syntax.
-          if [[ ! "$TAG_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(-(alpha|beta|rc)(\.[0-9]+)?)?$ ]]; then
+          # Accept historical title-cased pre-release labels while keeping the
+          # project version and all comparisons in their canonical lower-case form.
+          TAG_VERSION="${TAG_INPUT#v}"
+          NORMALIZED_TAG_VERSION="${TAG_VERSION,,}"
+          if [[ ! "$NORMALIZED_TAG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(-(alpha|beta|rc)(\.[0-9]+)?)?$ ]]; then
             echo "FAIL: tag '$TAG_INPUT' does not match the complete release version pattern"
             echo "Example: v0.1.15.3-alpha"
             exit 1
           fi
 
           PROJECT_VERSION=$(python -c "import json; print(json.load(open('packaging/portable/config/version.json', encoding='utf-8'))['release_version'])")
-          if [ "${TAG_INPUT#v}" != "$PROJECT_VERSION" ]; then
-            echo "FAIL: tag version '${TAG_INPUT#v}' does not match project version '$PROJECT_VERSION'"
+          if [ "$NORMALIZED_TAG_VERSION" != "${PROJECT_VERSION,,}" ]; then
+            echo "FAIL: tag version '$TAG_VERSION' does not match project version '$PROJECT_VERSION'"
             exit 1
           fi
 
@@ -681,7 +684,14 @@ jobs:
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
+          TAG_VERSION="${TAG#v}"
+          NORMALIZED_TAG_VERSION="${TAG_VERSION,,}"
+          PRERELEASE=false
+          if [[ "$NORMALIZED_TAG_VERSION" =~ -(alpha|beta|rc)(\.[0-9]+)?$ ]]; then
+            PRERELEASE=true
+          fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
 
       - name: Generate release notes from CHANGELOG
         id: changelog
@@ -711,6 +721,6 @@ jobs:
           files: |
             release-assets/*
           draft: false
-          prerelease: ${{ contains(steps.tag.outputs.tag, 'alpha') || contains(steps.tag.outputs.tag, 'beta') || contains(steps.tag.outputs.tag, 'rc') }}
+          prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 修复
 
+- **release**: Release 标签校验与 GitHub prerelease 判定统一使用小写规范化版本，兼容已有的 `-Alpha` 标签并避免被误判为正式版。
 - **ci/package**: CI 与 Release 在直接执行 `setup.py build_ext` 前显式安装 `setuptools>=77` 和固定版 Cython，修复 Windows Python 3.11 runner 使用旧构建后端时拒绝 SPDX `license = "MIT"` 的问题。
 - **portable/release**: Engine Pack 模型锁摘要统一按 LF 规范化换行后计算，消除同一 JSON 在 Windows CRLF 与 GitHub Actions LF checkout 下产生不同 SHA-256 的跨平台失败。
 - **license/release**: 项目代码正式采用 MIT License（Copyright (c) 2026 StarGazerQQD），并将许可证纳入 Python 包、Payload、Portable Lite/Full、GitHub Release 与发布完整性门禁。

--- a/packaging/portable/tests/test_release_fixture.py
+++ b/packaging/portable/tests/test_release_fixture.py
@@ -53,7 +53,20 @@ def test_release_tag_is_exact_and_matches_project_version() -> None:
 
     assert "complete release version pattern" in content
     assert "PROJECT_VERSION=" in content
-    assert 'if [ "${TAG_INPUT#v}" != "$PROJECT_VERSION" ]' in content
+    assert 'TAG_VERSION="${TAG_INPUT#v}"' in content
+    assert 'NORMALIZED_TAG_VERSION="${TAG_VERSION,,}"' in content
+    assert 'if [ "$NORMALIZED_TAG_VERSION" != "${PROJECT_VERSION,,}" ]' in content
+
+
+def test_release_title_case_prerelease_tag_remains_prerelease() -> None:
+    """历史 -Alpha 标签通过校验后仍必须创建为 GitHub prerelease。"""
+    release_yml = _PROJ_ROOT / ".github" / "workflows" / "release.yml"
+    content = release_yml.read_text(encoding="utf-8")
+
+    assert 'if [[ "$NORMALIZED_TAG_VERSION" =~ -(alpha|beta|rc)' in content
+    assert 'echo "prerelease=$PRERELEASE"' in content
+    assert "prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}" in content
+    assert "contains(steps.tag.outputs.tag, 'alpha')" not in content
 
 
 def test_release_smoke_checkout_includes_source_baseline_history() -> None:

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -214,9 +214,17 @@ def check_ci_bypass(audit: AuditResult) -> None:
         audit.check(
             "release.yml tag 与项目版本严格匹配",
             "PROJECT_VERSION=" in content
-            and 'if [ "${TAG_INPUT#v}" != "$PROJECT_VERSION" ]' in content
+            and 'NORMALIZED_TAG_VERSION="${TAG_VERSION,,}"' in content
+            and 'if [ "$NORMALIZED_TAG_VERSION" != "${PROJECT_VERSION,,}" ]' in content
             and "complete release version pattern" in content,
             "tag 必须完整匹配版本语法并等于项目版本真源",
+        )
+        audit.check(
+            "release.yml 预发布标签大小写兼容",
+            'if [[ "$NORMALIZED_TAG_VERSION" =~ -(alpha|beta|rc)' in content
+            and 'echo "prerelease=$PRERELEASE"' in content
+            and "prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}" in content,
+            "历史 -Alpha/-Beta/-RC 标签必须保持 GitHub prerelease 属性",
         )
     launcher_spec = REPO_ROOT / "packaging" / "portable" / "specs" / "portable_launcher.spec"
     if launcher_spec.exists():


### PR DESCRIPTION
## 根因

Release run `30262511710` 的 `Validate tag` job 收到标签 `v0.1.15.3-Alpha`，但工作流只接受小写 `-alpha`，因此在完整版本正则校验处失败。进一步审计还发现，创建 GitHub Release 时的 prerelease 判定同样区分大小写；若只放行校验，`-Alpha` 会被误标为正式版。

## 修改

- 校验前将标签版本规范化为小写，再执行完整语法和项目版本匹配。
- 保留原始标签名用于 Git 引用和 GitHub Release，兼容已有 `-Alpha`、`-Beta`、`-RC` 标签。
- 从规范化版本计算 prerelease 输出，避免大小写导致正式版误判。
- 补充 Release fixture 回归测试、发布审计门禁和 `CHANGELOG.md` 记录。

## 验证

- Git Bash 标签行为回归：大小写 Alpha 通过；版本不匹配与非法 `preview` 被拒绝；稳定版不标记 prerelease。
- `python -m pytest packaging/portable/tests/test_release_fixture.py -q`：19 passed。
- `python -m pytest tests/test_release_audit.py -q`：7 passed。
- `python scripts/ci_gate.py`：通过；主测试 730 passed，Portable 测试 284 passed，覆盖率 51.97%，两份 Runtime 锁依赖审计 clean。
- `python scripts/release_gate.py`：通过；Release Audit 58/58，Payload 构建与 184 文件契约通过，全部主测试和 Portable 测试通过。
- `git diff --check`：通过。

## 合并后注意

现有 `v0.1.15.3-Alpha` 标签仍指向旧提交，因此直接重新运行原失败 run 仍会使用旧工作流。合并后需先确认没有外部使用方依赖该失败标签，再将标签重新指向最新 `main` 后触发 Release；本 PR 不移动或删除任何标签。
