### PR TITLE
修复 Release Doctor 冒烟残留退出码

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -497,6 +497,7 @@ jobs:
             Write-Error "Lite EXE --doctor did not emit a verifiable failure summary"
             exit 1
           }
+          exit 0
         timeout-minutes: 5
 
       - name: Lite fresh-install to empty directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 修复
 
+- **release**: Lite Doctor 冒烟在验证预期失败摘要后显式返回成功，避免 PowerShell 保留原生命令的预期非零退出码而误判整个 Release step 失败。
 - **release**: Release 标签校验与 GitHub prerelease 判定统一使用小写规范化版本，兼容已有的 `-Alpha` 标签并避免被误判为正式版。
 - **ci/package**: CI 与 Release 在直接执行 `setup.py build_ext` 前显式安装 `setuptools>=77` 和固定版 Cython，修复 Windows Python 3.11 runner 使用旧构建后端时拒绝 SPDX `license = "MIT"` 的问题。
 - **portable/release**: Engine Pack 模型锁摘要统一按 LF 规范化换行后计算，消除同一 JSON 在 Windows CRLF 与 GitHub Actions LF checkout 下产生不同 SHA-256 的跨平台失败。

--- a/packaging/portable/tests/test_release_fixture.py
+++ b/packaging/portable/tests/test_release_fixture.py
@@ -19,6 +19,15 @@ def test_release_workflow_has_smoke_tests() -> None:
     assert "--doctor" in content, "Release workflow missing Lite EXE --doctor smoke test"
     assert "--diagnose" not in content, "Release workflow calls an unsupported launcher argument"
     assert "$doctorExit -eq 0" in content, "Release workflow must reject a false-success Doctor result"
+    workflow = yaml.safe_load(content)
+    doctor_step = next(
+        step
+        for step in workflow["jobs"]["smoke-test"]["steps"]
+        if step.get("name") == "Lite EXE --doctor rejects incomplete environment"
+    )
+    assert doctor_step["run"].rstrip().endswith("exit 0"), (
+        "Expected Doctor failure must be normalized to a successful smoke step"
+    )
     assert "scripts/smoke_portable_lite.py" in content
 
     smoke_script = (_PROJ_ROOT / "scripts" / "smoke_portable_lite.py").read_text(encoding="utf-8")

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -162,6 +162,9 @@ def check_ci_bypass(audit: AuditResult) -> None:
     if release_yml.exists():
         content = release_yml.read_text(encoding="utf-8")
         lite_smoke = lite_smoke_py.read_text(encoding="utf-8") if lite_smoke_py.is_file() else ""
+        doctor_start = content.find("- name: Lite EXE --doctor rejects incomplete environment")
+        doctor_end = content.find("- name: Lite fresh-install to empty directory", doctor_start)
+        doctor_smoke = content[doctor_start:doctor_end] if doctor_start >= 0 and doctor_end > doctor_start else ""
         audit.check("release.yml 无 BLC_CI_BUILD", "BLC_CI_BUILD" not in content)
         audit.check(
             "release.yml 无 BLC_FIXTURE_BUILD",
@@ -205,6 +208,13 @@ def check_ci_bypass(audit: AuditResult) -> None:
             and "_wait_ready" in lite_smoke
             and '["--offline", "--engine-pack"' in lite_smoke,
             "Lite smoke 必须完成空目录安装、Web 就绪和二次断网复用",
+        )
+        audit.check(
+            "release.yml Doctor 预期失败退出码归一化",
+            "$doctorExit -eq 0" in doctor_smoke
+            and "Diagnostics complete: .* FAIL" in doctor_smoke
+            and "exit 0" in doctor_smoke,
+            "Doctor 按设计返回非零后，验证成功路径必须显式清除原生命令退出码",
         )
         audit.check(
             "release.yml 跨制品身份校验",


### PR DESCRIPTION
## 根因

Release run `30264161637` 的 `Smoke tests (Lite + Full)` job 在 `Lite EXE --doctor rejects incomplete environment` step 失败。Doctor 按设计在不完整环境中返回非零并输出 `Diagnostics complete: 3 PASS, 2 WARN, 3 FAIL`；工作流正确验证了退出码和摘要，却没有在成功分支末尾显式返回零，PowerShell 保留的原生命令退出码导致 GitHub Actions 将整个 step 误判为失败。

失败 job：https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30264161637/job/89973437288

## 修改

- Doctor 预期失败通过断言后显式 `exit 0`，只清除已验证的残留退出码。
- 回归测试精确定位 Doctor smoke step，并要求其成功路径以 `exit 0` 结束。
- Release Audit 增加同一契约的 fail-closed 检查。
- 同步 `CHANGELOG.md`。

## 影响

不改变 Doctor 的退出码、诊断语义、Portable 行为或公开接口；仅修正 Release 工作流对预期失败测试的最终判定。

## 验证

- 相关 pytest：26 passed。
- `python scripts/ci_gate.py`：通过；主测试 730 passed，Portable 测试 284 passed，覆盖率 51.95%，两份 Runtime 锁依赖审计 clean。
- `python scripts/release_gate.py`：通过；Release Audit 59/59，Payload 构建与 184 文件契约通过，全部测试通过。
- Ruff check/format、版本一致性与 `git diff --check`：通过。

## 合并后注意

当前 `v0.1.15.3-Alpha` 标签指向修复前的 `406b0572`。合并后直接重跑原 Release 仍会使用旧工作流；需要在确认标签使用边界后，将标签重新指向合并后的最新 `main` 再触发 Release。本 PR 不移动或删除标签。
