### PR TITLE
修复 Lite smoke 中文日志回显

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 修复
 
+- **release**: Lite 首次安装 smoke 驱动在入口将 stdout/stderr 切换为 UTF-8，修复 Windows runner 使用 `cp1252` 回显中文 Launcher 日志时触发 `UnicodeEncodeError`。
 - **release**: Lite Doctor 冒烟在验证预期失败摘要后显式返回成功，避免 PowerShell 保留原生命令的预期非零退出码而误判整个 Release step 失败。
 - **release**: Release 标签校验与 GitHub prerelease 判定统一使用小写规范化版本，兼容已有的 `-Alpha` 标签并避免被误判为正式版。
 - **ci/package**: CI 与 Release 在直接执行 `setup.py build_ext` 前显式安装 `setuptools>=77` 和固定版 Cython，修复 Windows Python 3.11 runner 使用旧构建后端时拒绝 SPDX `license = "MIT"` 的问题。

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -206,8 +206,10 @@ def check_ci_bypass(audit: AuditResult) -> None:
             "scripts/smoke_portable_lite.py" in content
             and "Lite fresh online installation and second offline launch OK" in lite_smoke
             and "_wait_ready" in lite_smoke
-            and '["--offline", "--engine-pack"' in lite_smoke,
-            "Lite smoke 必须完成空目录安装、Web 就绪和二次断网复用",
+            and '["--offline", "--engine-pack"' in lite_smoke
+            and "_configure_console_encoding()" in lite_smoke
+            and 'reconfigure(encoding="utf-8", errors="backslashreplace")' in lite_smoke,
+            "Lite smoke 必须完成空目录安装、Web 就绪、UTF-8 日志回显和二次断网复用",
         )
         audit.check(
             "release.yml Doctor 预期失败退出码归一化",

--- a/scripts/smoke_portable_lite.py
+++ b/scripts/smoke_portable_lite.py
@@ -22,6 +22,18 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 VERSION_CONFIG = REPO_ROOT / "packaging" / "portable" / "config" / "version.json"
 
 
+def _configure_console_encoding() -> None:
+    """Use UTF-8 output when the host console supports stream reconfiguration."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (OSError, TypeError, ValueError):
+            continue
+
+
 def _required_file(directory: Path, filename: str, label: str) -> Path:
     """Return the exact current-version artifact from a directory."""
     path = directory / filename
@@ -196,6 +208,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     """Resolve smoke artifacts, run both phases, and report the result."""
+    _configure_console_encoding()
     args = parse_args(argv)
     try:
         version_config = json.loads(VERSION_CONFIG.read_text(encoding="utf-8"))

--- a/tests/unit/test_lite_smoke_tool.py
+++ b/tests/unit/test_lite_smoke_tool.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import io
 import json
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -51,3 +53,36 @@ def test_main_passes_resolved_artifacts_to_smoke(tmp_path: Path, monkeypatch: Mo
         == 0
     )
     assert observed == [(executable.resolve(), engine_pack.resolve())]
+
+
+def test_main_prints_utf8_launcher_log_on_legacy_console(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """The Windows smoke driver must survive Chinese launcher diagnostics on cp1252 hosts."""
+    lite_dir = tmp_path / "lite"
+    engine_dir = tmp_path / "engine"
+    lite_dir.mkdir()
+    engine_dir.mkdir()
+    version_config = json.loads(smoke_portable_lite.VERSION_CONFIG.read_text(encoding="utf-8"))
+    version = version_config["release_version"]
+    (lite_dir / version_config["naming"]["lite_exe"].format(version=version)).write_bytes(b"exe")
+    (engine_dir / version_config["naming"]["engine_pack_zip"].format(version=version)).write_bytes(b"zip")
+    log_path = tmp_path / "launcher.log"
+    log_path.write_text("模型准备完成：中文日志", encoding="utf-8")
+
+    stdout_bytes = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_bytes, encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr(
+        smoke_portable_lite,
+        "run_smoke",
+        lambda *_args, **_kwargs: smoke_portable_lite._print_log(log_path),
+    )
+
+    result = smoke_portable_lite.main(["--lite-dir", str(lite_dir), "--engine-pack-dir", str(engine_dir)])
+    stdout.flush()
+    stderr.flush()
+
+    assert result == 0
+    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+    assert "模型准备完成：中文日志" in stdout_bytes.getvalue().decode("utf-8")


### PR DESCRIPTION
## 根因

Release 的 `Smoke tests (Lite + Full)` 在 Windows runner 上失败。Lite smoke 驱动以 UTF-8 读取 Launcher 日志后，直接向仍为 `cp1252` 的外层 Python stdout 输出；中文诊断触发 `UnicodeEncodeError`，导致 smoke 流程在报告日志时崩溃。

失败任务：https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30266767613/job/89983385745

## 修改

- 在 Lite smoke 驱动入口将 stdout/stderr 配置为 UTF-8，并使用 `backslashreplace` 作为不可编码字符的安全回退。
- 新增真实 `cp1252` 控制台回归测试，验证中文 Launcher 日志能够完整输出。
- 将编码保护纳入发布审计，防止后续移除。
- 同步更新 V0.1.15.3 变更日志。

## 影响

仅调整 Release 外层 Lite smoke 驱动的控制台输出编码；不改变 Portable Launcher、公开接口、配置格式或用户运行行为。

## 验证

- 目标测试：`29 passed`
- `scripts/ci_gate.py`：通过（主测试 `731 passed`，Portable 测试 `284 passed`，覆盖率 `51.95%`）
- `scripts/release_gate.py`：通过（发布审计 `59/59`、Ruff、版本一致性、锁文件审计、Payload 合约 `184 files`、主测试和 Portable 测试全部通过）
- `git diff --check`：通过

## 合并后事项

当前发布标签 `v0.1.15.3-Alpha` 仍指向发生失败的 `53533980`。合并后需要将发布标签重新指向新的 main 合并提交并触发同 SHA 的 Release；本 PR 不移动标签，也不执行发布。
