### PR TITLE
修复 macOS 全量覆盖测试超时

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
           if-no-files-found: warn
 
 # macOS runner 明显慢于 Linux/Windows，仅在 main 分支推送时执行。
+# 全量覆盖测试的历史耗时已接近 30 分钟，保留 45 分钟预算以容纳正常波动和新增回归用例。
 # 独立 job 可使用真正的 job-level if；matrix.include 中的 if 只是普通数据字段。
   test-macos:
     name: "macos-latest / py3.12"
@@ -210,7 +211,7 @@ jobs:
         env:
           ASR_NO_MODEL_DOWNLOAD: "1"
         run: python scripts/run_coverage.py
-        timeout-minutes: 30
+        timeout-minutes: 45
 
       - name: Upload coverage report
         if: always()

--- a/tests/unit/test_release_tooling.py
+++ b/tests/unit/test_release_tooling.py
@@ -198,6 +198,15 @@ def test_windows_payload_jobs_run_on_windows_and_verify_native_modules() -> None
     assert "Full Bundle native acceleration OK" in release_source
 
 
+def test_macos_coverage_timeout_has_runtime_headroom() -> None:
+    """macOS 全量覆盖测试必须为正常运行波动保留足够余量。"""
+    ci_workflow = yaml.safe_load((run_ruff.REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"))
+    steps = ci_workflow["jobs"]["test-macos"]["steps"]
+    coverage_step = next(step for step in steps if step.get("run") == "python scripts/run_coverage.py")
+
+    assert coverage_step["timeout-minutes"] >= 45
+
+
 def test_release_gate_audits_portable_runtime_locks() -> None:
     source = (run_ruff.REPO_ROOT / "scripts" / "release_gate.py").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 根因

最新 `main` 提交 `b7191455d8ec0defdcc8ccfe2fe3a12c2f67a394` 的 macOS 全量覆盖测试并无断言失败，而是在 850 项测试正常跑到 99% 后触发 30 分钟步骤超时。上一条成功的 macOS 覆盖步骤已耗时 29 分 47 秒，原上限只剩 13 秒余量，新增正常回归用例后稳定越界。

失败证据：

- CI：https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30682903748
- macOS job：https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30682903748/job/91323258430

## 修改

- 将 macOS 全量覆盖测试的超时预算从 30 分钟调整为 45 分钟，为正常 runner 波动与后续回归用例保留余量。
- 新增工作流回归测试，要求 macOS 覆盖步骤至少保留 45 分钟预算，防止配置再次退化。

## 影响

仅调整 `main` 推送时的 macOS CI 门禁预算，不改变应用运行时、版本、依赖、Portable Payload 内容或发布行为。

## 验证

- `pytest tests/unit/test_release_tooling.py`：17/17 通过。
- 完整主测试：851/851 通过。
- 完整 Portable 测试：286/286 通过。
- Ruff check / format、版本一致性、发布快速审计、前端交互检查：通过。
- `scripts/ci_gate.py`：通过；覆盖率 60.90%，两份 runtime lock 审计无漏洞。
- `scripts/release_gate.py`：8/8 通过；发布审计 59/59，Payload 契约 205 文件。

## 提交

- `e367320` 修复 macOS 全量测试超时
