### PR TITLE
docs: 增加发布版本与许可徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # BiliLiveCut — AI 直播实时切片系统
 
 [![CI](https://github.com/StarGazerQQD/BiliLiveCut/actions/workflows/ci.yml/badge.svg)](https://github.com/StarGazerQQD/BiliLiveCut/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/StarGazerQQD/BiliLiveCut?include_prereleases&sort=semver)](https://github.com/StarGazerQQD/BiliLiveCut/releases)
+[![License](https://img.shields.io/github/license/StarGazerQQD/BiliLiveCut)](LICENSE)
 
 **当前版本：V0.1.16.4 Alpha** (`0.1.16.4-alpha`)
 


### PR DESCRIPTION
## 修改内容

- 在 README 顶部增加 Release 版本徽章，并包含预发布版本。
- 增加 License 许可徽章，链接到仓库根目录的 MIT `LICENSE`。

## 修改原因

让访问仓库的用户能直接确认当前发布版本与项目许可类型，不必额外进入 Releases 或查找许可证文件。

## 影响范围

仅修改 README 展示，不改变程序、配置或发布产物。

## 验证

- README 徽章格式与链接目标检查通过。
- `python scripts/check_version_consistency.py` 通过。
- `python scripts/release_gate.py` 全部通过：发布审计、依赖审计、Ruff、格式、payload 契约、870 项主测试与 286 项 portable 测试。
- `python scripts/ci_gate.py` 全部通过，主测试覆盖率为 61.69%。
