### PR TITLE
升级 Portable runtime 加密依赖锁

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 未发布
 
+### 修复
+
+- **portable/security**: 将 Python 3.11/3.12 Windows runtime lock 中的 `cryptography` 升级并固定为 `50.0.0`，修复 `GHSA-g6cj-pr64-35w5` / `CVE-2026-69247`，并重新生成完整依赖闭包与 wheel SHA-256。
+
 ## V0.1.16.5 Alpha (2026-08-03)
 
 ### 变更

--- a/packaging/portable/locks/requirements-runtime-py311-win-x64.lock
+++ b/packaging/portable/locks/requirements-runtime-py311-win-x64.lock
@@ -14,12 +14,12 @@ audioread==3.1.0 --hash=sha256:b30d1df6c5d3de5dcef0fb0e256f6ea17bdcf5f979408df02
 av==18.0.0 --hash=sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629  # av-18.0.0-cp311-abi3-win_amd64.whl
 brotli==1.2.0 --hash=sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24  # brotli-1.2.0-cp311-cp311-win_amd64.whl
 certifi==2026.7.22 --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775  # certifi-2026.7.22-py3-none-any.whl
-cffi==2.1.0 --hash=sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458  # cffi-2.1.0-cp311-cp311-win_amd64.whl
+cffi==2.1.1 --hash=sha256:42f6930c31dc7f50732c9ae793c2786c7b6b044195967bbdde40bb9be81c4cc0  # cffi-2.1.1-cp311-cp311-win_amd64.whl
 charset-normalizer==3.4.9 --hash=sha256:6366a16e1a25018694d6a5d784d09b046edc9eac40ea2b54065c3052672516a1  # charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl
 click==8.4.2 --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76  # click-8.4.2-py3-none-any.whl
 colorama==0.4.6 --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6  # colorama-0.4.6-py2.py3-none-any.whl
 crcmod==1.7 --hash=sha256:a5c73de3c773b72cc842002639640626e4511c51e122056111a732f398af3931  # crcmod-1.7-py3-none-any.whl
-cryptography==49.0.0 --hash=sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e  # cryptography-49.0.0-cp311-abi3-win_amd64.whl
+cryptography==50.0.0 --hash=sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30  # cryptography-50.0.0-cp311-abi3-win_amd64.whl
 ctranslate2==4.8.1 --hash=sha256:82982f07a7d615d2248d17d6ec4c43cd50e534b094aa27cda62125a5e3a6e3fc  # ctranslate2-4.8.1-cp311-cp311-win_amd64.whl
 decorator==5.3.1 --hash=sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c  # decorator-5.3.1-py3-none-any.whl
 distro==1.9.0 --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2  # distro-1.9.0-py3-none-any.whl
@@ -31,7 +31,7 @@ fsspec==2026.7.0 --hash=sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e
 funasr==1.3.30 --hash=sha256:b5d1544a6c8cf0cd5518e1b34636293f534f6ad15d8400c0fbc46d49390f6918  # funasr-1.3.30-py3-none-any.whl
 greenlet==3.5.4 --hash=sha256:dc418cf4c873357964d6624445ed09472e50def990c65dd4e76fc3ba8cd9cef6  # greenlet-3.5.4-cp311-cp311-win_amd64.whl
 h11==0.16.0 --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86  # h11-0.16.0-py3-none-any.whl
-hf-xet==1.5.2 --hash=sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65  # hf_xet-1.5.2-cp38-abi3-win_amd64.whl
+hf-xet==1.6.0 --hash=sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b  # hf_xet-1.6.0-cp38-abi3-win_amd64.whl
 httpcore==1.0.9 --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55  # httpcore-1.0.9-py3-none-any.whl
 httptools==0.8.0 --hash=sha256:a1b4c8e7a489a0d750d91894e9a8cdc295838f1924c0ca903ae993456fddec07  # httptools-0.8.0-cp311-cp311-win_amd64.whl
 httpx==0.28.1 --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad  # httpx-0.28.1-py3-none-any.whl
@@ -54,7 +54,7 @@ markdown-it-py==4.2.0 --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6f
 markupsafe==3.0.3 --hash=sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01  # markupsafe-3.0.3-cp311-cp311-win_amd64.whl
 mdurl==0.1.2 --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8  # mdurl-0.1.2-py3-none-any.whl
 modelscope==1.39.0 --hash=sha256:a363298e4620db83b3ec0057a23a73c4ee1fa122ca11b375e72ef94874123efa  # modelscope-1.39.0-py3-none-any.whl
-modelscope-hub==0.1.8 --hash=sha256:905ffd0a64c99bd34d40a72452dba97611f702b1887c11ba694584fb46d25420  # modelscope_hub-0.1.8-py3-none-any.whl
+modelscope-hub==0.2.0 --hash=sha256:84668c80c1d36d1fb1ea1ce17b707d77e044b92255288618c3b7de5b13834418  # modelscope_hub-0.2.0-py3-none-any.whl
 mpmath==1.3.0 --hash=sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c  # mpmath-1.3.0-py3-none-any.whl
 msgpack==1.2.1 --hash=sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8  # msgpack-1.2.1-cp311-cp311-win_amd64.whl
 narwhals==2.24.0 --hash=sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489  # narwhals-2.24.0-py3-none-any.whl

--- a/packaging/portable/locks/requirements-runtime-py312-win-x64.lock
+++ b/packaging/portable/locks/requirements-runtime-py312-win-x64.lock
@@ -14,12 +14,12 @@ audioread==3.1.0 --hash=sha256:b30d1df6c5d3de5dcef0fb0e256f6ea17bdcf5f979408df02
 av==18.0.0 --hash=sha256:aaf4d354d2beaa6651e4f92e54409a578bde64f79c0beef9a30b388d06f7c629  # av-18.0.0-cp311-abi3-win_amd64.whl
 brotli==1.2.0 --hash=sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44  # brotli-1.2.0-cp312-cp312-win_amd64.whl
 certifi==2026.7.22 --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775  # certifi-2026.7.22-py3-none-any.whl
-cffi==2.1.0 --hash=sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384  # cffi-2.1.0-cp312-cp312-win_amd64.whl
+cffi==2.1.1 --hash=sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a  # cffi-2.1.1-cp312-cp312-win_amd64.whl
 charset-normalizer==3.4.9 --hash=sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0  # charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl
 click==8.4.2 --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76  # click-8.4.2-py3-none-any.whl
 colorama==0.4.6 --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6  # colorama-0.4.6-py2.py3-none-any.whl
 crcmod==1.7 --hash=sha256:a5c73de3c773b72cc842002639640626e4511c51e122056111a732f398af3931  # crcmod-1.7-py3-none-any.whl
-cryptography==49.0.0 --hash=sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e  # cryptography-49.0.0-cp311-abi3-win_amd64.whl
+cryptography==50.0.0 --hash=sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30  # cryptography-50.0.0-cp311-abi3-win_amd64.whl
 ctranslate2==4.8.1 --hash=sha256:49f96e861b57301f0b76a082109bde2cac8204a6b4fedc870883008271e82251  # ctranslate2-4.8.1-cp312-cp312-win_amd64.whl
 decorator==5.3.1 --hash=sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c  # decorator-5.3.1-py3-none-any.whl
 distro==1.9.0 --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2  # distro-1.9.0-py3-none-any.whl
@@ -31,7 +31,7 @@ fsspec==2026.7.0 --hash=sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e
 funasr==1.3.30 --hash=sha256:b5d1544a6c8cf0cd5518e1b34636293f534f6ad15d8400c0fbc46d49390f6918  # funasr-1.3.30-py3-none-any.whl
 greenlet==3.5.4 --hash=sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3  # greenlet-3.5.4-cp312-cp312-win_amd64.whl
 h11==0.16.0 --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86  # h11-0.16.0-py3-none-any.whl
-hf-xet==1.5.2 --hash=sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65  # hf_xet-1.5.2-cp38-abi3-win_amd64.whl
+hf-xet==1.6.0 --hash=sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b  # hf_xet-1.6.0-cp38-abi3-win_amd64.whl
 httpcore==1.0.9 --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55  # httpcore-1.0.9-py3-none-any.whl
 httptools==0.8.0 --hash=sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150  # httptools-0.8.0-cp312-cp312-win_amd64.whl
 httpx==0.28.1 --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad  # httpx-0.28.1-py3-none-any.whl
@@ -54,7 +54,7 @@ markdown-it-py==4.2.0 --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6f
 markupsafe==3.0.3 --hash=sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c  # markupsafe-3.0.3-cp312-cp312-win_amd64.whl
 mdurl==0.1.2 --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8  # mdurl-0.1.2-py3-none-any.whl
 modelscope==1.39.0 --hash=sha256:a363298e4620db83b3ec0057a23a73c4ee1fa122ca11b375e72ef94874123efa  # modelscope-1.39.0-py3-none-any.whl
-modelscope-hub==0.1.8 --hash=sha256:905ffd0a64c99bd34d40a72452dba97611f702b1887c11ba694584fb46d25420  # modelscope_hub-0.1.8-py3-none-any.whl
+modelscope-hub==0.2.0 --hash=sha256:84668c80c1d36d1fb1ea1ce17b707d77e044b92255288618c3b7de5b13834418  # modelscope_hub-0.2.0-py3-none-any.whl
 mpmath==1.3.0 --hash=sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c  # mpmath-1.3.0-py3-none-any.whl
 msgpack==1.2.1 --hash=sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24  # msgpack-1.2.1-cp312-cp312-win_amd64.whl
 narwhals==2.24.0 --hash=sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489  # narwhals-2.24.0-py3-none-any.whl

--- a/packaging/portable/locks/requirements-runtime.in
+++ b/packaging/portable/locks/requirements-runtime.in
@@ -23,6 +23,7 @@ loguru==0.7.3
 typer==0.27.0
 rich==15.0.0
 brotli==1.2.0
+cryptography==50.0.0
 pyyaml==6.0.3
 numpy==2.4.6
 torch==2.13.0

--- a/packaging/portable/tests/test_runtime_locks.py
+++ b/packaging/portable/tests/test_runtime_locks.py
@@ -81,6 +81,7 @@ def test_runtime_locks_cover_core_application_imports() -> None:
 def test_runtime_locks_keep_security_upgrades_pinned() -> None:
     expected = {
         "aiofiles": "25.1.0",
+        "cryptography": "50.0.0",
         "fastapi": "0.141.1",
         "faster-whisper": "1.2.1",
         "funasr": "1.3.30",


### PR DESCRIPTION
## 根因

PR #34 检查通过后，GitHub Advisory Database 新发布了 `GHSA-g6cj-pr64-35w5` / `CVE-2026-69247`。Portable 的 Python 3.11/3.12 Windows runtime lock 仍固定 `cryptography==49.0.0`，因此合并后的 `main` 在阻断式 `pip-audit` 中失败。

失败任务：https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30867585857/job/91862702460

## 修改

- 在 runtime 依赖输入中固定 `cryptography==50.0.0`。
- 使用 `scripts/generate_portable_runtime_locks.py` 重新生成 Python 3.11 与 3.12 Windows x64 严格哈希锁。
- 同步安全版本回归测试与未发布变更日志。
- 重新解析同时带入兼容传递升级：`cffi 2.1.1`、`hf-xet 1.6.0`、`modelscope-hub 0.2.0`；两个锁仍各含 116 个包。

## 验证

- `pytest packaging/portable/tests/test_runtime_locks.py -q`：6 passed
- `scripts/audit_portable_runtime_locks.py`：两个锁均为 116 dependencies, clean
- 完整主测试：通过
- 完整 Portable 测试：通过
- Ruff lint / format：通过
- `compileall` 与 `setup.py build_ext --inplace`：通过
- `scripts/ci_gate.py`：通过（890 主测试、286 Portable 测试、覆盖率 62.52%）
- `scripts/release_gate.py`：通过（59 项发布审计、208 文件 Payload 合约）

本 PR 为 Draft，不执行合并。
