### PR TITLE
修复 Release 的 FFmpeg 下载单点故障

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,18 +332,8 @@ jobs:
         timeout-minutes: 15
 
       - name: Download FFmpeg static binaries
-        shell: pwsh
-        run: |
-          Write-Output "::group::Downloading FFmpeg"
-          Invoke-WebRequest -Uri "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip" `
-            -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
-          Expand-Archive -Path "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg-extracted" -Force
-          New-Item -ItemType Directory -Path bin -Force
-          $ffmpegDir = Get-ChildItem "$env:RUNNER_TEMP\ffmpeg-extracted" -Directory | Select-Object -First 1
-          Copy-Item "$($ffmpegDir.FullName)\bin\ffmpeg.exe" "bin\ffmpeg.exe"
-          Copy-Item "$($ffmpegDir.FullName)\bin\ffprobe.exe" "bin\ffprobe.exe"
-          Write-Output "::endgroup::"
-        timeout-minutes: 5
+        run: python scripts/download_release_ffmpeg.py --output-dir bin
+        timeout-minutes: 15
 
       - name: Download Windows wheels from lock files
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 未发布
 
-暂无。
+### 修复
+
+- **release/ffmpeg-download**: Windows Release 构建不再单点依赖 Gyan FFmpeg 下载源；改用 BtbN 主源与 Gyan 备用源，按来源进行有限指数退避重试，并在安全提取前校验 ZIP 完整性，避免第三方临时 `503` 直接中断整个发布。
 
 ## V0.1.17 Alpha (2026-08-05)
 

--- a/scripts/download_release_ffmpeg.py
+++ b/scripts/download_release_ffmpeg.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""为 GitHub Release 下载并校验 Windows FFmpeg 静态构建。"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import tempfile
+import time
+import urllib.request
+import zipfile
+from collections.abc import Callable, Sequence
+from pathlib import Path, PurePosixPath
+
+PRIMARY_URL = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
+FALLBACK_URL = "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip"
+DEFAULT_URLS = (PRIMARY_URL, FALLBACK_URL)
+DEFAULT_ATTEMPTS = 3
+DEFAULT_BACKOFF_S = 2.0
+DEFAULT_TIMEOUT_S = 90.0
+REQUIRED_BINARIES = ("ffmpeg.exe", "ffprobe.exe")
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+DownloadFunction = Callable[[str, Path, float], None]
+SleepFunction = Callable[[float], None]
+
+
+def _download_archive(url: str, destination: Path, timeout_s: float) -> None:
+    """把单个候选 URL 流式下载到临时文件。"""
+    request = urllib.request.Request(  # noqa: S310 - URL 固定在受审计的发布脚本中
+        url,
+        headers={"User-Agent": "BiliLiveCut-release-builder"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout_s) as response, destination.open("wb") as output:  # noqa: S310
+        shutil.copyfileobj(response, output, length=DOWNLOAD_CHUNK_SIZE)
+    if destination.stat().st_size <= 0:
+        raise RuntimeError("下载结果为空文件")
+
+
+def _required_members(package: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
+    """定位 ZIP 中唯一的 FFmpeg/FFprobe 可执行文件。"""
+    matches: dict[str, list[zipfile.ZipInfo]] = {name: [] for name in REQUIRED_BINARIES}
+    for member in package.infolist():
+        normalized = member.filename.replace("\\", "/")
+        parts = PurePosixPath(normalized).parts
+        if member.is_dir() or not parts:
+            continue
+        if normalized.startswith("/") or ".." in parts or parts[0].endswith(":"):
+            raise RuntimeError(f"FFmpeg ZIP 包含不安全路径: {member.filename}")
+        name = parts[-1].lower()
+        if len(parts) >= 2 and parts[-2].lower() == "bin" and name in matches:
+            matches[name].append(member)
+
+    resolved: dict[str, zipfile.ZipInfo] = {}
+    for name, candidates in matches.items():
+        if len(candidates) != 1:
+            raise RuntimeError(f"FFmpeg ZIP 中 {name} 数量异常: {len(candidates)}")
+        if candidates[0].file_size <= 0:
+            raise RuntimeError(f"FFmpeg ZIP 中 {name} 为空文件")
+        resolved[name] = candidates[0]
+    return resolved
+
+
+def _verify_and_extract(archive_path: Path, output_dir: Path) -> None:
+    """完整校验 ZIP，并把两个必需文件安全提取到目标目录。"""
+    staging_dir = archive_path.parent / "staged"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir()
+
+    with zipfile.ZipFile(archive_path) as package:
+        corrupt_member = package.testzip()
+        if corrupt_member is not None:
+            raise RuntimeError(f"FFmpeg ZIP CRC 校验失败: {corrupt_member}")
+        members = _required_members(package)
+        for name in REQUIRED_BINARIES:
+            destination = staging_dir / name
+            with package.open(members[name]) as source, destination.open("wb") as output:
+                shutil.copyfileobj(source, output, length=DOWNLOAD_CHUNK_SIZE)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name in REQUIRED_BINARIES:
+        staged = staging_dir / name
+        if staged.stat().st_size <= 0:
+            raise RuntimeError(f"提取后的 {name} 为空文件")
+        staged.replace(output_dir / name)
+
+
+def download_release_ffmpeg(
+    output_dir: Path,
+    *,
+    urls: Sequence[str] = DEFAULT_URLS,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff_s: float = DEFAULT_BACKOFF_S,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    download: DownloadFunction | None = None,
+    sleep: SleepFunction = time.sleep,
+) -> str:
+    """按来源重试下载 FFmpeg，并返回最终成功的 URL。"""
+    if attempts < 1:
+        raise ValueError("attempts 必须至少为 1")
+    if backoff_s < 0 or timeout_s <= 0:
+        raise ValueError("backoff_s 必须非负且 timeout_s 必须为正数")
+    if not urls:
+        raise ValueError("至少需要一个 FFmpeg 下载源")
+
+    downloader = download or _download_archive
+    output_parent = output_dir.resolve().parent
+    output_parent.mkdir(parents=True, exist_ok=True)
+    errors: list[str] = []
+    last_error: Exception | None = None
+
+    with tempfile.TemporaryDirectory(prefix="blc-release-ffmpeg-", dir=output_parent) as temp_dir:
+        archive_path = Path(temp_dir) / "ffmpeg.zip"
+        for url in urls:
+            for attempt in range(1, attempts + 1):
+                archive_path.unlink(missing_ok=True)
+                print(f"FFmpeg 下载: source={url} attempt={attempt}/{attempts}", flush=True)
+                try:
+                    downloader(url, archive_path, timeout_s)
+                    _verify_and_extract(archive_path, output_dir)
+                except (EOFError, OSError, RuntimeError, shutil.Error, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+                    last_error = exc
+                    errors.append(f"{url} attempt {attempt}/{attempts}: {type(exc).__name__}: {exc}")
+                    if attempt < attempts:
+                        delay = backoff_s * (2 ** (attempt - 1))
+                        print(f"FFmpeg 下载失败，{delay:.1f}s 后重试: {exc}", file=sys.stderr, flush=True)
+                        sleep(delay)
+                    continue
+                print(f"FFmpeg 下载与校验完成: source={url} output={output_dir}", flush=True)
+                return url
+
+    detail = "\n".join(errors)
+    raise RuntimeError(f"所有 FFmpeg 下载源均失败:\n{detail}") from last_error
+
+
+def _positive_int(value: str) -> int:
+    """解析正整数命令行参数。"""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("必须至少为 1")
+    return parsed
+
+
+def _non_negative_float(value: str) -> float:
+    """解析非负浮点命令行参数。"""
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("不得小于 0")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """创建 Release FFmpeg 下载器参数解析器。"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True, help="ffmpeg.exe/ffprobe.exe 输出目录")
+    parser.add_argument("--attempts", type=_positive_int, default=DEFAULT_ATTEMPTS, help="每个来源的最大尝试次数")
+    parser.add_argument(
+        "--backoff-seconds",
+        type=_non_negative_float,
+        default=DEFAULT_BACKOFF_S,
+        help="重试的初始退避秒数",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_S, help="单次请求超时秒数")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """运行命令行下载器。"""
+    args = build_parser().parse_args(argv)
+    if args.timeout_seconds <= 0:
+        print("ERROR: --timeout-seconds 必须为正数", file=sys.stderr)
+        return 2
+    print("::group::Downloading FFmpeg")
+    try:
+        download_release_ffmpeg(
+            args.output_dir,
+            attempts=args.attempts,
+            backoff_s=args.backoff_seconds,
+            timeout_s=args.timeout_seconds,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        print("::endgroup::")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -145,6 +145,7 @@ def check_ci_bypass(audit: AuditResult) -> None:
     lite_py = REPO_ROOT / "packaging" / "portable" / "src" / "blc_portable" / "builders" / "lite.py"
     release_yml = REPO_ROOT / ".github" / "workflows" / "release.yml"
     lite_smoke_py = REPO_ROOT / "scripts" / "smoke_portable_lite.py"
+    ffmpeg_download_py = REPO_ROOT / "scripts" / "download_release_ffmpeg.py"
 
     if lite_py.exists():
         content = lite_py.read_text(encoding="utf-8")
@@ -162,6 +163,7 @@ def check_ci_bypass(audit: AuditResult) -> None:
     if release_yml.exists():
         content = release_yml.read_text(encoding="utf-8")
         lite_smoke = lite_smoke_py.read_text(encoding="utf-8") if lite_smoke_py.is_file() else ""
+        ffmpeg_download = ffmpeg_download_py.read_text(encoding="utf-8") if ffmpeg_download_py.is_file() else ""
         doctor_start = content.find("- name: Lite EXE --doctor rejects incomplete environment")
         doctor_end = content.find("- name: Lite fresh-install to empty directory", doctor_start)
         doctor_smoke = content[doctor_start:doctor_end] if doctor_start >= 0 and doctor_end > doctor_start else ""
@@ -237,6 +239,15 @@ def check_ci_bypass(audit: AuditResult) -> None:
             and 'echo "prerelease=$PRERELEASE"' in content
             and "prerelease: ${{ steps.tag.outputs.prerelease == 'true' }}" in content,
             "历史 -Alpha/-Beta/-RC 标签必须保持 GitHub prerelease 属性",
+        )
+        audit.check(
+            "release.yml FFmpeg 下载具备重试与备用源",
+            "python scripts/download_release_ffmpeg.py --output-dir bin" in content
+            and "BtbN/FFmpeg-Builds" in ffmpeg_download
+            and "www.gyan.dev" in ffmpeg_download
+            and "DEFAULT_ATTEMPTS = 3" in ffmpeg_download
+            and "testzip()" in ffmpeg_download,
+            "Release 必须通过受测下载器重试多个来源，并在提取前校验 FFmpeg ZIP",
         )
     launcher_spec = REPO_ROOT / "packaging" / "portable" / "specs" / "portable_launcher.spec"
     if launcher_spec.exists():

--- a/tests/unit/test_release_ffmpeg_download.py
+++ b/tests/unit/test_release_ffmpeg_download.py
@@ -1,0 +1,93 @@
+"""Release FFmpeg 下载器的离线回归测试。"""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import download_release_ffmpeg
+
+
+def _build_ffmpeg_fixture(path: Path) -> None:
+    """创建同时兼容 BtbN/Gyan 目录结构的最小 ZIP。"""
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as package:
+        package.writestr("ffmpeg-fixture/bin/ffmpeg.exe", b"ffmpeg-binary")
+        package.writestr("ffmpeg-fixture/bin/ffprobe.exe", b"ffprobe-binary")
+
+
+def test_download_retries_primary_then_validates_and_uses_fallback(tmp_path: Path) -> None:
+    """主源持续 503、备用源首包损坏时仍应重试并只落盘完整文件。"""
+    fixture = tmp_path / "fixture.zip"
+    output_dir = tmp_path / "bin"
+    _build_ffmpeg_fixture(fixture)
+    calls: list[tuple[str, float]] = []
+    sleeps: list[float] = []
+    per_url_attempts: dict[str, int] = {}
+
+    def fake_download(url: str, destination: Path, timeout_s: float) -> None:
+        calls.append((url, timeout_s))
+        per_url_attempts[url] = per_url_attempts.get(url, 0) + 1
+        if url == "primary":
+            raise OSError("503 Service Unavailable")
+        if per_url_attempts[url] == 1:
+            destination.write_bytes(b"not-a-zip")
+            return
+        shutil.copyfile(fixture, destination)
+
+    selected = download_release_ffmpeg.download_release_ffmpeg(
+        output_dir,
+        urls=("primary", "fallback"),
+        attempts=2,
+        backoff_s=0.25,
+        timeout_s=12.0,
+        download=fake_download,
+        sleep=sleeps.append,
+    )
+
+    assert selected == "fallback"
+    assert calls == [
+        ("primary", 12.0),
+        ("primary", 12.0),
+        ("fallback", 12.0),
+        ("fallback", 12.0),
+    ]
+    assert sleeps == [0.25, 0.25]
+    assert (output_dir / "ffmpeg.exe").read_bytes() == b"ffmpeg-binary"
+    assert (output_dir / "ffprobe.exe").read_bytes() == b"ffprobe-binary"
+
+
+def test_download_fails_closed_without_partial_binaries(tmp_path: Path) -> None:
+    """全部来源失败时必须聚合错误，且不得留下伪造可执行文件。"""
+    output_dir = tmp_path / "bin"
+
+    def fail_download(url: str, destination: Path, timeout_s: float) -> None:
+        del destination, timeout_s
+        raise OSError(f"unavailable: {url}")
+
+    with pytest.raises(RuntimeError, match="所有 FFmpeg 下载源均失败") as error:
+        download_release_ffmpeg.download_release_ffmpeg(
+            output_dir,
+            urls=("primary", "fallback"),
+            attempts=1,
+            download=fail_download,
+            sleep=lambda _delay: None,
+        )
+
+    assert "primary attempt 1/1" in str(error.value)
+    assert "fallback attempt 1/1" in str(error.value)
+    assert not output_dir.exists()
+
+
+def test_release_workflow_uses_resilient_ffmpeg_downloader() -> None:
+    """Release 工作流必须调用受测下载器并预留完整重试时间。"""
+    repo_root = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load((repo_root / ".github/workflows/release.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["build-windows-lite"]["steps"]
+    step = next(item for item in steps if item.get("name") == "Download FFmpeg static binaries")
+
+    assert step["run"] == "python scripts/download_release_ffmpeg.py --output-dir bin"
+    assert step["timeout-minutes"] >= 10


### PR DESCRIPTION
## 根因

Windows Release 的 Lite 构建只从 Gyan 下载 FFmpeg。该第三方下载源连续两次返回 `503 Service Unavailable`，导致整个 Release 在下载步骤直接失败：

- Workflow：[`Release`](https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30989333481)
- Job：[`Build Windows Lite EXE`](https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30989333481/job/92256264702)
- 失败步骤：`Download FFmpeg static binaries`

## 修改

- 新增受测的 Release FFmpeg 下载器，以 BtbN 为主源、Gyan 为备用源。
- 每个来源最多尝试 3 次，使用有限指数退避，并保留单次请求超时。
- 下载后执行 ZIP CRC、路径安全、必需文件数量与非空校验，只提取 `ffmpeg.exe` 和 `ffprobe.exe`。
- 将 Release 工作流接入下载器，并把步骤超时提高到 15 分钟，为最坏重试路径保留余量。
- 扩展发布审计并补充离线回归测试，覆盖主源失败、备用源损坏后重试、全部来源失败关闭门禁等场景。
- 更新未发布变更记录。

## 验证

- 目标回归：`10 passed`
- `python scripts/ci_gate.py`：通过
  - 主测试：`930 passed`
  - Portable 测试：`286 passed`
  - 覆盖率：`64.24%`
- `python scripts/release_gate.py`：通过
  - 完整发布审计：`60 PASS / 0 WARN / 0 FAIL`
  - Payload 契约：`211 files`
- Ruff、版本一致性、两份 Portable runtime lock 审计：全部通过

## 影响

后续由包含本提交的 Release 工作流构建时，单一 FFmpeg 镜像的临时故障不再直接中断发布；所有来源都失败或包内容异常时仍会明确失败，不会使用不完整二进制。
