### PR TITLE
修复 Release 下载器的 Windows 控制台编码

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 修复
 
-- **release/ffmpeg-download**: Windows Release 构建不再单点依赖 Gyan FFmpeg 下载源；改用 BtbN 主源与 Gyan 备用源，按来源进行有限指数退避重试，并在安全提取前校验 ZIP 完整性，避免第三方临时 `503` 直接中断整个发布。
+- **release/ffmpeg-download**: Windows Release 构建不再单点依赖 Gyan FFmpeg 下载源；改用 BtbN 主源与 Gyan 备用源，按来源进行有限指数退避重试，并在安全提取前校验 ZIP 完整性；下载器在输出日志前主动切换 UTF-8，避免第三方临时 `503` 或 Windows `charmap` 代码页直接中断整个发布。
 
 ## V0.1.17 Alpha (2026-08-05)
 

--- a/scripts/download_release_ffmpeg.py
+++ b/scripts/download_release_ffmpeg.py
@@ -26,6 +26,18 @@ DownloadFunction = Callable[[str, Path, float], None]
 SleepFunction = Callable[[float], None]
 
 
+def _configure_console_encoding() -> None:
+    """在宿主支持时将输出切换为 UTF-8，避免旧版 Windows 代码页无法输出中文。"""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (OSError, TypeError, ValueError):
+            continue
+
+
 def _download_archive(url: str, destination: Path, timeout_s: float) -> None:
     """把单个候选 URL 流式下载到临时文件。"""
     request = urllib.request.Request(  # noqa: S310 - URL 固定在受审计的发布脚本中
@@ -168,6 +180,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """运行命令行下载器。"""
+    _configure_console_encoding()
     args = build_parser().parse_args(argv)
     if args.timeout_seconds <= 0:
         print("ERROR: --timeout-seconds 必须为正数", file=sys.stderr)

--- a/scripts/release_audit.py
+++ b/scripts/release_audit.py
@@ -246,8 +246,9 @@ def check_ci_bypass(audit: AuditResult) -> None:
             and "BtbN/FFmpeg-Builds" in ffmpeg_download
             and "www.gyan.dev" in ffmpeg_download
             and "DEFAULT_ATTEMPTS = 3" in ffmpeg_download
-            and "testzip()" in ffmpeg_download,
-            "Release 必须通过受测下载器重试多个来源，并在提取前校验 FFmpeg ZIP",
+            and "testzip()" in ffmpeg_download
+            and 'reconfigure(encoding="utf-8", errors="backslashreplace")' in ffmpeg_download,
+            "Release 必须通过受测下载器重试多个来源、切换 UTF-8，并在提取前校验 FFmpeg ZIP",
         )
     launcher_spec = REPO_ROOT / "packaging" / "portable" / "specs" / "portable_launcher.spec"
     if launcher_spec.exists():

--- a/tests/unit/test_release_ffmpeg_download.py
+++ b/tests/unit/test_release_ffmpeg_download.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import io
 import shutil
+import sys
 import zipfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
 
 from scripts import download_release_ffmpeg
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
 
 
 def _build_ffmpeg_fixture(path: Path) -> None:
@@ -80,6 +86,37 @@ def test_download_fails_closed_without_partial_binaries(tmp_path: Path) -> None:
     assert "primary attempt 1/1" in str(error.value)
     assert "fallback attempt 1/1" in str(error.value)
     assert not output_dir.exists()
+
+
+def test_main_reconfigures_narrow_windows_console_before_logging(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """CP1252 控制台也必须能输出下载器的中文日志。"""
+    fixture = tmp_path / "fixture.zip"
+    output_dir = tmp_path / "bin"
+    _build_ffmpeg_fixture(fixture)
+    stdout_bytes = io.BytesIO()
+    stderr_bytes = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_bytes, encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(stderr_bytes, encoding="cp1252", errors="strict")
+
+    def fake_download(url: str, destination: Path, timeout_s: float) -> None:
+        del url, timeout_s
+        shutil.copyfile(fixture, destination)
+
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr(download_release_ffmpeg, "_download_archive", fake_download)
+
+    exit_code = download_release_ffmpeg.main(["--output-dir", str(output_dir), "--attempts", "1"])
+    stdout.flush()
+    stderr.flush()
+
+    assert exit_code == 0
+    assert stdout.encoding.lower().replace("_", "-") == "utf-8"
+    assert stderr.encoding.lower().replace("_", "-") == "utf-8"
+    assert "FFmpeg 下载与校验完成" in stdout_bytes.getvalue().decode("utf-8")
 
 
 def test_release_workflow_uses_resilient_ffmpeg_downloader() -> None:


### PR DESCRIPTION
## 背景

最新 `main` 提交 `d7b9e6a4b1a0562b5c5dd42ff67e7ff8b40782a8` 的 Release 在 Windows Lite 构建中失败：

- Workflow：[`Release`](https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30995270207)
- Job：[`Build Windows Lite EXE`](https://github.com/StarGazerQQD/BiliLiveCut/actions/runs/30995270207/job/92273367897)
- 失败步骤：`Download FFmpeg static binaries`

根因是 Windows runner 的 Python 输出仍使用 `charmap`/CP1252。下载器第一次输出中文日志时触发 `UnicodeEncodeError`，尚未开始网络下载就退出，因此此前加入的多源重试无法生效。

## 修改

- 下载器进入 `main()` 后立即将 `stdout` 和 `stderr` 切换为 UTF-8，并使用可控的反斜杠降级策略。
- 新增严格 CP1252 控制台回归测试，覆盖真实命令入口和中文成功日志。
- 发布审计强制校验 UTF-8 初始化逻辑，防止后续回退。
- 更新未发布变更记录。

## 影响

Windows Release 下载 FFmpeg 时不再因系统代码页无法编码中文而提前失败；下载、重试、ZIP 校验和安全提取行为保持不变。

## 验证

- 目标测试：`11 passed`
- `scripts/ci_gate.py`：通过（主测试 931 项、Portable 测试 286 项，覆盖率 64.23%）
- `scripts/release_gate.py`：通过（发布审计 60/60、版本一致性、runtime lock、Ruff、payload 构建及两组完整测试全部通过）
- `git diff --check`：通过
